### PR TITLE
fix/vue-component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngVue",
   "author": "Doray Hong <hongduhui@gmail.com>",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Use Vue Components in Angular 1.x",
   "main": "build/ngVue.umd.js",
   "jsnext:main": "build/ngVue.es.js",

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,6 @@ function ngVueComponentFactory ($injector) {
   return function (componentName, ngDirectiveConfig) {
     const config = {
       restrict: 'E',
-      replace: true,
       link (scope, elem, attrs) {
         ngVueLinker(componentName, elem, attrs, scope, $injector)
       }
@@ -44,12 +43,11 @@ function ngVueComponentFactory ($injector) {
  * <vue-component name="HelloComponent" vprops="person"></vue-component>
  *
  * @param $injector
- * @returns {{restrict: string, replace: boolean, link: (function(*=, *=, *=))}}
+ * @returns {{restrict: string, link: (function(*=, *=, *=))}}
  */
 function ngVueComponentDirective ($injector) {
   return {
     restrict: 'E',
-    replace: true,
     link (scope, elem, attrs) {
       const componentName = attrs.name
       ngVueLinker(componentName, elem, attrs, scope, $injector)


### PR DESCRIPTION
`replace` boolean property in the directives configuration object is deprecated in AngularJS. And as the documentation states: `specify what the template should replace`. The `vue-component` directive doesn't use `template` property so, anyway, it is not used whether it is true of false.

What do you think about removing it?