### PR TITLE
ng filters in VueJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The motivation for this is similar to ngReact's:
 
 ## Features
 
-**ngVue** is composed of a directive `vue-component`, a factory `createVueComponent` and a directive helper `vdirectives`
+**ngVue** is composed of a directive `vue-component`, a factory `createVueComponent` and a directive helper `vdirectives`. It also provides some plugins for enhancement.
 
 - `vue-component` is a directive that delegates data to a Vue component so VueJS can compile it with the corresponding nodes
 - `createVueComponent` is a factory that converts a Vue component into a `vue-component` directive
@@ -130,12 +130,100 @@ app.directive('helloComponent', function (createVueComponent) {
 })
 ```
 
+## Plugins
+
+> this is an experimental feature
+
+What if I want to use Angular filters in VueJS templates? Is it possible to use vuex to manage the state? How can I reuse the business code in VueJS when the application is too deep into Angular 1.x? ... 
+
+There are more complicated problems when we try to integrate Angular 1.x with VueJS. It is impossible to solve them all but it's important to provide flexibility for enhancement while keeping **ngVue** small and simple. So we introduce a new module **ngVue.plugins**.
+
+### the `$ngVue` provider
+
+> `$ngVue` is a built-in module for now but will be moved out from the module `ngVue` at a later time
+
+**ngVue.plugins** creates the Angular provider `$ngVue`. This provider is responsible for registering **plugins**. Those **plugins** control the Vue instances with the lifecycle hooks, so you can simply use VueJS plugins or retrieve Angular modules resolved by the inject service and then apply them to VueJS.
+
+#### API: `install(callback)`
+
+The provider `$ngVue` has only one method `install` to use a plugin during the configuration phase of Angular.
+
+**Arguments**
+
+- `callback` (*Function*): the callback function receives the inject service `$injector` and this service injects the provider instances only. The callback should return a plain object `{$name[, $config, $vue, $plugin]}`: 
+
+	- `$name` (*String*): required to avoid name collisions in the provider, it is used as the namespace in the `$ngVue` provider
+	- `$config` (*Object*): optional, it contains the methods for users to set up the plugin and those methods will be exposed only to the namespace object created by `$name` in the `$ngVue` provider
+	- `$vue` (*Object*): optional, it contains the lifecycle hooks of the Vue instances
+	- `$plugin` (*Object*): optional, it contains the lifecycle hooks of the ngVue plugins
+
+#### lifecycle hooks
+
+There are two types of lifecycle hooks:
+
+| type | hook name |
+| --- | --- |
+| ngVue plugins | init |
+| Vue instances | beforeCreated, created, beforeMount, mounted, beforeUpdate, updated, beforeDestroy, destroyed |
+
+For the ngVue plugin hook `init`, it is invoked when the service `$ngVue` is instantiated by the inject service. It is when you can add global-level functionality to VueJS.
+
+The Vue instance hooks will be invoked when any Vue instance in Angular application calls its own lifecycle hooks. You can subscribe those hooks to do anything with Angular services (it is not recommended to use Angular services in Vue components).
+
+Those hooks share the same signature `($injector, Vue, context) => void`:
+
+- ``$injector`` the injector service that can access to all the instantiated services
+- ``Vue`` the base class of Vue instances
+- ``context`` only useful for the Vue instance hooks, the context points to the Vue instance invoking it
+
+### available plugins
+
+- *(built-in)* ngVue.plugins.filter
+
+### install a plugin
+
+Require `ngVue.plugins` and the plugin module. That's it :-)
+
+```javascript
+angular.module('app', ['ngVue.plugins', 'custom.plugin'])
+```
+
+### set up a plugin
+
+Each ngVue plugin has a namespace object (defined by the plugin's `$name`) and all the configuration options are contained there
+
+```javascript
+angular.module('app', ['ngVue.plugins', 'custom.plugin'])
+	.config(function($ngVueProvider) {
+		$ngVueProvider.namespace.configMethod()
+	})
+```
+
+### write a plugin
+
+Require the module `ngVue.plugins` and then install the plugin in `$ngVue` provider during the configuration phase:
+
+```javascript
+angular.module('custom.plugin', ['ngVue.plugins'])
+	.config(function($ngVueProvider) {
+		$ngVueProvider.install(($injector) => {
+			// do something with other providers injected by `$injector`
+			return {
+				$name: 'namespace',
+				$config: { ...configMethod },
+				$plugin: { ...pluginHooks },
+				$vue: { ...vueHooks }
+			}
+		})
+	})
+```
+
 ## TODO
 
 - [x] vue components
 - [x] vue directives
 - [ ] unit tests
 - [x] docs + simple examples
-- [ ] ng filters in VueJS
+- [x] ng filters in VueJS
 - [ ] supports vuex
 - [ ] performance optimization

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Those hooks share the same signature `($injector, Vue, context) => void`:
 
 ### available plugins
 
-- *(built-in)* ngVue.plugins.filter
+- *(built-in)* [ngVue.plugins.filter](docs/ngVue.plugins.filters.md)
 
 ### install a plugin
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ The motivation for this is similar to ngReact's:
 - The VueJS community offers a component or a UI framework that you would like to try out
 - Too deep into an AngularJS application to move it away from the code but you would like to experiment with VueJS
 
+**Table of Contents**
+
+- [Features](#features)
+	- [the `vue-component` directive](#the-vue-component-directive)
+	- [the `createVueComponent` factory](#the-createvuecomponent-factory)
+- [Plugins](#plugins)
+	- [the `$ngVue` provider](#the-ngvue-provider)
+	- [available plugins](#available-plugins)
+	- [install a plugin](#install-a-plugin)
+	- [set up a plugin](#set-up-a-plugin)
+	- [write a plugin](#write-a-plugin)
+
 ## Features
 
 **ngVue** is composed of a directive `vue-component`, a factory `createVueComponent` and a directive helper `vdirectives`. It also provides some plugins for enhancement.

--- a/docs/ngVue.plugins.filters.md
+++ b/docs/ngVue.plugins.filters.md
@@ -1,0 +1,57 @@
+# ngVue.plugins.filters
+
+> This plugin allows you to use Angular filters in VueJS templates.
+
+The plugin collects all the registered filters and then calls `Vue.use` to inject them into Vue.
+
+## API
+
+The namespace of the plugin is `filters` and this namespace object is the only access to the methods it provides.
+
+### `register(filters)`
+
+Register a list of filters to VueJS.
+
+**Arguments**
+
+- `filters` (*Object\<String, Function>* | *Array\<String>*): If it's an object, the key will be the filter name and the value will be the function that transforms input to an output. If it's a list of filter names, they will be resolved by the inject service of Angular.
+
+## Usage
+
+You should register the filters during the configuration phase:
+
+```javascript
+angular.module('app', ['ngVue.plugins', 'ngVue.plugins.filters'])
+	.config(function ($ngVueProvider) {
+		$ngVueProvider.filters.register({
+			'f1': (input) => output,
+			'f2': (input) => output
+		})
+		// or
+		$ngVueProvider.filters.register(['f3', 'f4'])
+	})
+	.filter('f3', () => (input) => output)
+	.filter('f4', () => (input) => output)
+```
+
+Angular filters and VueJS filters are both pure functions, so you can use them in the render functions of VueJS to transform the input by invoking `Vue.filter(id)`:
+
+```javascript
+new Vue({
+	...
+	render(h) {
+		const filter = Vue.filter('name')
+		return <div>{ filter(text) }</div>
+	}
+})
+```
+
+You can also use them inside mustache interpolations and `v-bind` expressions:
+
+```javascript
+<template>
+	<div>{{ text | filter }}</div>
+</template>
+```
+
+

--- a/example/plugins-filters/index.html
+++ b/example/plugins-filters/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Hello, World</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/css/materialize.min.css">
+  <style>
+    html, body {
+      width: 100%;
+      height: 100%;
+    }
+    body {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .hello-card {
+      width: 500px;
+    }
+  </style>
+</head>
+<body ng-app="vue.components">
+  <div class="hello-card"
+       ng-controller="MainController as ctrl">
+    <vue-component name="HelloComponent"
+                   vprops="ctrl.person"
+                   watch-depth="value"></vue-component>
+    <vue-component name="TagsComponent"></vue-component>
+    <div class="row">
+      <div class="col s6">
+        <input class="row"
+               type="text"
+               ng-model="ctrl.person.firstName"
+               placeholder="first name"
+               autofocus>
+      </div>
+      <div class="col s6">
+        <input class="row"
+               type="text"
+               ng-model="ctrl.person.lastName"
+               placeholder="last name">
+      </div>
+      <div class="input-field col s12">
+        <textarea class="materialize-textarea"
+                  ng-model="ctrl.person.description"></textarea>
+      </div>
+    </div>
+  </div>
+  <script src="/assets/plugins-filters.build.js"></script>
+</body>
+</html>

--- a/example/plugins-filters/index.js
+++ b/example/plugins-filters/index.js
@@ -1,0 +1,42 @@
+import angular from 'angular'
+import Vue from 'vue'
+import '../../build/ngVue.es'
+import Tags from './tags.vue'
+
+angular.module('vue.components', ['ngVue'])
+  .config(function ($ngVueProvider) {
+    $ngVueProvider.filters.register(['uppercase'])
+  })
+  .filter('uppercase', function () {
+    return (string) => string.toUpperCase()
+  })
+  .controller('MainController', function () {
+    this.person = {
+      firstName: 'The',
+      lastName: 'World',
+      description: 'ngVue helps you use Vue components in your angular application ' +
+                   'so that you are able to create a faster and reactive web interfaces.'
+    }
+  })
+  .value('TagsComponent', Tags)
+  .value('HelloComponent', Vue.component('hello-component', {
+    props: {
+      firstName: String,
+      lastName: String,
+      description: String
+    },
+    render (h) {
+      const uppercase = Vue.filter('uppercase')
+      return (
+        <div class="card blue-grey darken-1">
+          <div class="card-content white-text">
+            <span class="card-title">Hi, {this.firstName} {this.lastName}</span>
+            <p>{uppercase(this.description)}</p>
+          </div>
+          <div class="card-action">
+            <a href="https://vuejs.org/guide/overview.html">Vue.js</a>
+          </div>
+        </div>
+      )
+    }
+  }))

--- a/example/plugins-filters/tags.vue
+++ b/example/plugins-filters/tags.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="tags">
+    <div v-for="tag in tags" class="chip">
+      {{ tag | uppercase }}
+    </div>
+  </div>
+</template>
+<style scoped>
+  .tags {
+    text-align: right;
+    margin-bottom: 30px;
+  }
+</style>
+<script>
+  export default {
+    data () {
+      return {
+        tags: ['angular', 'ngVue', 'VueJS']
+      }
+    }
+  }
+</script>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngVue",
   "author": "Doray Hong <hongduhui@gmail.com>",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Use Vue Components in Angular 1.x",
   "main": "build/ngVue.umd.js",
   "jsnext:main": "build/ngVue.es.js",

--- a/src/angular/ngVueLinker.js
+++ b/src/angular/ngVueLinker.js
@@ -6,22 +6,32 @@ import evalPropValues from '../components/props/evaluateValues'
 import evaluateDirectives from '../directives/evaluateDirectives'
 
 export function ngVueLinker (componentName, jqElement, elAttributes, scope, $injector) {
+  const $ngVue = $injector.has('$ngVue') ? $injector.get('$ngVue') : null
+
   const dataExprsMap = getPropExprs(elAttributes)
   const Component = getVueComponent(componentName, $injector)
   const directives = evaluateDirectives(elAttributes, scope) || []
   const reactiveData = evalPropValues(dataExprsMap, scope) || {}
   const reactiveSetter = Vue.set.bind(Vue, reactiveData)
-  const vueInstance = new Vue({
+
+  let vueOptions = {
     el: jqElement[0],
     data: reactiveData,
     render (h) {
       return <Component {...{ directives }} {...{ props: reactiveData }} />
     }
-  })
+  }
+
+  if ($ngVue) {
+    const hooks = $ngVue.getVueHooks()
+    vueOptions = { ...vueOptions, ...hooks }
+  }
+
+  const vueInstance = new Vue(vueOptions)
 
   watchPropExprs(dataExprsMap, reactiveSetter, elAttributes, scope)
 
   scope.$on('$destroy', () => {
-    vueInstance.$destroy(true)
+    vueInstance.$destroy()
   })
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import angular from 'angular'
 import { ngVueLinker } from './angular/ngVueLinker'
+import './plugins/provider'
+import './plugins/filters'
 
 /**
  *
@@ -55,6 +57,6 @@ function ngVueComponentDirective ($injector) {
   }
 }
 
-export const ngVue = angular.module('ngVue', [])
+export const ngVue = angular.module('ngVue', ['ngVue.plugins', 'ngVue.plugins.filters'])
   .directive('vueComponent', ['$injector', ngVueComponentDirective])
   .factory('createVueComponent', ['$injector', ngVueComponentFactory])

--- a/src/plugins/filters.js
+++ b/src/plugins/filters.js
@@ -1,0 +1,56 @@
+import angular, { isArray, isObject } from 'angular'
+import './provider'
+
+// contains all the registered filter functions
+const registered = Object.create(null)
+
+// these string filters will be resolved by `$filter` service
+let lazyStringFilters = []
+
+// add an ng filter function
+function addFilter (name, filter) {
+  registered[name] = filter
+}
+
+// resolve the strings with $injector
+function resolveStringFilters ($injector) {
+  const $filter = $injector.get('$filter')
+
+  lazyStringFilters.forEach((name) => {
+    addFilter(name, $filter(name))
+  })
+
+  lazyStringFilters = []
+}
+
+// register a list of ng filters to ngVue
+function registerFilters (filters) {
+  if (isArray(filters)) {
+    lazyStringFilters = lazyStringFilters.concat(filters)
+  } else if (isObject(filters)) {
+    Object.keys(filters).forEach((name) => {
+      addFilter(name, filters[name])
+    })
+  }
+}
+
+// a Vue plugin will register the ng filters to Vue
+const ngFilters = (Vue) => {
+  const filterNames = Object.keys(registered)
+  filterNames.forEach((name) => Vue.filter(name, registered[name]))
+}
+
+// initialize all the ng filters and install the ngFilters plugin
+const onPluginInit = ($injector, Vue) => {
+  resolveStringFilters($injector)
+  Vue.use(ngFilters)
+}
+
+export default angular.module('ngVue.plugins.filters', ['ngVue.plugins'])
+  .config(['$ngVueProvider', ($ngVueProvider) => {
+    $ngVueProvider.install(() => ({
+      $name: 'filters',
+      $config: { register: registerFilters },
+      $plugin: { init: onPluginInit }
+    }))
+  }])

--- a/src/plugins/provider.js
+++ b/src/plugins/provider.js
@@ -1,0 +1,76 @@
+import angular, { extend } from 'angular'
+import Vue from 'vue'
+
+// init
+const pluginHooks = Object.create(null)
+
+// beforeCreated
+// created
+// beforeMount
+// mounted
+// beforeUpdate
+// updated
+// beforeDestroy
+// destroyed
+const vueHooks = Object.create(null)
+
+function addHooks (map, hooks) {
+  if (hooks) {
+    Object.keys(hooks).forEach((h) => {
+      map[h] = map[h] ? map[h] : []
+      map[h].push(hooks[h])
+    })
+  }
+}
+
+function callHooks (map, name, callback) {
+  const hooks = map[name]
+  if (hooks) {
+    hooks.forEach(callback)
+  }
+}
+
+function createVueHooksMap (hookCallback) {
+  return Object.keys(vueHooks).reduce((available, name) => ({
+    ...available,
+    [name]: function () {
+      const _cb = hookCallback.bind(this)
+      callHooks(vueHooks, name, _cb)
+    }
+  }), {})
+}
+
+function ngVueProvider ($injector) {
+  this.install = (plugin) => {
+    const {
+      $name,
+      $config,
+      $plugin,
+      $vue
+    } = plugin($injector)
+
+    addHooks(pluginHooks, $plugin)
+    addHooks(vueHooks, $vue)
+
+    extend(this, {
+      [$name]: $config
+    })
+  }
+
+  this.$get = ['$injector', ($injector) => {
+    const cb = function (hook) {
+      hook($injector, Vue, /* dynamic context */ this)
+    }
+
+    callHooks(pluginHooks, 'init', cb)
+
+    const vueHooks = createVueHooksMap(cb)
+
+    return {
+      getVueHooks: () => vueHooks
+    }
+  }]
+}
+
+export default angular.module('ngVue.plugins', [])
+  .provider('$ngVue', ['$injector', ngVueProvider])


### PR DESCRIPTION
close #9 

I wanna keep **ngVue** simple and small, so I decided to create another module **ngVue.plugins**. This module hides the details of `ngVueLinker` (a directive link function describes how to link the angular directive to the Vue component) and provides flexibility to enhance **ngVue** with some lifecycle hooks so that we can develop more plugins without touching the core. At a later time, I'll move it into another repo ;-) Then I created a plugin **ngVue.plugins.filters**. It allows us to reuse Angular filters in VueJS.

### TODO
- [x] a ngVue provider
- [x] a plugin for ng filters
- [x] documentation
- [x] example code
