### PR TITLE
fix issue on tracking reference changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngVue",
   "author": "Doray Hong <hongduhui@gmail.com>",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Use Vue Components in Angular 1.x",
   "main": "build/ngVue.umd.js",
   "jsnext:main": "build/ngVue.es.js",

--- a/src/components/props/watchExpressions.js
+++ b/src/components/props/watchExpressions.js
@@ -5,19 +5,34 @@ function watch (expressions, reactiveData) {
   return (watchFunc) => {
     // for `vprops` / `vdata`
     if (isString(expressions)) {
-      watchFunc(expressions, (newVal) => {
-        Vue.set(reactiveData, '_v', isArray(newVal) ? [...newVal] : newVal)
-      })
+      watchFunc(expressions, Vue.set.bind(Vue, reactiveData, '_v'))
       return
     }
 
     // for `vprops-something`
     Object.keys(expressions)
       .forEach((name) => {
-        watchFunc(expressions[name], (newVal) => {
-          Vue.set(reactiveData._v, name, isArray(newVal) ? [...newVal] : newVal)
-        })
+        watchFunc(expressions[name], Vue.set.bind(Vue, reactiveData._v, name))
       })
+  }
+}
+
+/**
+ * @param setter Function a reactive setter from VueKS
+ * @returns Function a watch callback when the expression value is changed
+ */
+function notify (setter) {
+  return function (newVal) {
+    // `Vue.set` use a shallow comparision to detect the change, so...
+    //
+    // (1) For an array, we have to create a new one to get around the limitation that
+    //     the shallow comparison cannot detect the reference change of the array element
+    // (2) For an object, we don't need to create a new one because the object is reactive
+    //     and any changes of the properties will notify the reactivity system
+    // (3) If the reference is changed in Angular Scope, the shallow comparison can detect
+    //     it and then trigger view updates
+    //
+    setter(isArray(newVal) ? [...newVal] : newVal)
   }
 }
 
@@ -43,18 +58,18 @@ export default function watchExpressions (dataExprsMap, reactiveData, depth, sco
   switch (depth) {
     case 'value':
       watcher((expression, setter) => {
-        scope.$watch(expression, setter, true)
+        scope.$watch(expression, notify(setter), true)
       })
       break
     case 'collection':
       watcher((expression, setter) => {
-        scope.$watchCollection(expression, setter)
+        scope.$watchCollection(expression, notify(setter))
       })
       break
     case 'reference':
     default:
       watcher((expression, setter) => {
-        scope.$watch(expression, setter)
+        scope.$watch(expression, notify(setter))
       })
   }
 }


### PR DESCRIPTION
The component properties derived from Angular scopes are wrapped in a plain object `{ _v: componentProperties }` and so VueJS can be notified by those changes:

- [x] changing the reference of the object (`this.person = {name: 'newPerson'}`)
- [x] changing the reference of any element in the array (`this.persons[0] = {name: 'newPerson'}`)

