### PR TITLE
Fix an issue where the Vue instance element is not removed

### DIFF
--- a/src/angular/ngVueLinker.js
+++ b/src/angular/ngVueLinker.js
@@ -33,5 +33,6 @@ export function ngVueLinker (componentName, jqElement, elAttributes, scope, $inj
 
   scope.$on('$destroy', () => {
     vueInstance.$destroy()
+    vueInstance.$el.remove()
   })
 }


### PR DESCRIPTION
Hello, thanks for making this! We found an issue where if you had `<vue-component ng-if="somethingThatBecomesFalse" ... />`, the Vue instance doesn't get removed because `$destroy` doesn't remove the element by default.