### PR TITLE
chore(dependencies): move angular and vue to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngVue",
   "author": "Doray Hong <hongduhui@gmail.com>",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Use Vue Components in Angular 1.x",
   "main": "build/index.js",
   "keywords": [
@@ -23,11 +23,9 @@
     "preversion": "npm run test",
     "prepublish": "npm run build"
   },
-  "dependencies": {
-    "angular": "^1.6.4",
-    "vue": "^2.3.3"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "angular": "^1.6.8",
     "angular-mocks": "^1.6.4",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
@@ -56,8 +54,9 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-uglify": "^2.0.1",
     "uglify-js": "^3.0.11",
+    "vue": "^2.5.13",
     "vue-loader": "^12.1.0",
-    "vue-template-compiler": "^2.3.3",
+    "vue-template-compiler": "^2.5.13",
     "webpack": "^2.6.1",
     "webpack-dev-server": "^2.4.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,9 +78,9 @@ angular-mocks@^1.6.4:
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/angular-mocks/-/angular-mocks-1.6.4.tgz#47fdf50921cf24fb489f100a8cf2ad99d0538f40"
 
-angular@^1.6.4:
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/angular/-/angular-1.6.4.tgz#03b7b15c01a0802d7e2cf593240e604054dc77fb"
+angular@^1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/angular/-/angular-1.6.8.tgz#5be378a58be91a5489e78b59c4518cd9fd273ffb"
 
 ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
   version "1.4.0"
@@ -5033,9 +5033,9 @@ vue-style-loader@^3.0.0:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue-template-compiler@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.3.3.tgz#b5bab9ec57309c906b82a78c81a02179dbc2f470"
+vue-template-compiler@^2.5.13:
+  version "2.5.13"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.5.13.tgz#12a2aa0ecd6158ac5e5f14d294b0993f399c3d38"
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"
@@ -5044,9 +5044,9 @@ vue-template-es2015-compiler@^1.2.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.5.0.tgz#e4f672ab1718a3abf9171a080daefac31be117e1"
 
-vue@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.3.3.tgz#d1eaa8fde5240735a4563e74f2c7fead9cbb064c"
+vue@^2.5.13:
+  version "2.5.13"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.13.tgz#95bd31e20efcf7a7f39239c9aa6787ce8cf578e1"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
Move angular and vue to `devDependencies` to prevent message:

> WARNING: Tried to load angular more than once.

from `node_modules/ngVue/node_modules/angular/angular.js`, in an app where Angular.js is already a dependency.