### PR TITLE
feat(ngvue-linker): name component for debugging

### DIFF
--- a/src/angular/ngVueLinker.js
+++ b/src/angular/ngVueLinker.js
@@ -23,6 +23,7 @@ export function ngVueLinker (componentName, jqElement, elAttributes, scope, $inj
   watchPropExprs(dataExprsMap, reactiveData, watchOptions, scope)
 
   const vueInstance = new Vue({
+    name: 'NgVue',
     el: jqElement[0],
     data: reactiveData,
     render (h) {


### PR DESCRIPTION
Hello again, I have another one-liner if interested. This makes the component show up as `<NgVue>` in the Vue debugger component tree and in Vue component stack traces, which for me helps to know where Vue ends and Angular begins.