### PR TITLE
Add Vuex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,5 +234,5 @@ ngVue is simple but flexible for enhancement. Please read more in the [Plugins](
 - [x] unit tests
 - [x] docs + simple examples
 - [x] ng filters in VueJS
-- [ ] supports vuex
+- [x] supports vuex
 - [ ] performance optimization

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -136,3 +136,37 @@ angular.module('yourApp', ['ngVue', 'ngVue.plugins'])
 	})
 ```
 
+## Vuex
+
+Vuex support is a bit opinionated and its implementation focuses on simplicity. You _must_ use `Vue.use(Vuex)`
+to enable automatic injection of the store into child components.
+Then, import (or define) your `Vuex.Store` instance and tell `ngVue` to use it on all Vue instances created by it.
+
+You can enabled it during the config phase of the Angular.js app:
+
+```javascript
+// store.js
+import Vue
+import Vuex
+
+Vue.use(Vuex)
+
+export default new Vuex.Store({
+	state: {
+		message: 'Hello from ngVue!'
+	}
+})
+```
+
+```javascript
+// app.js
+import store from './store'
+
+angular.module('yourApp', ['ngVue', 'ngVue.plugins'])
+  .config(($ngVueProvider) => {
+		$ngVueProvider.enableVuex(store)
+	})
+```
+
+All components created by `ngVue` will have access to `this.$store`, as described in the 
+[Vuex documentation](https://vuex.vuejs.org/en/state.html)

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "vue": "^2.5.13",
     "vue-loader": "^12.1.0",
     "vue-template-compiler": "^2.5.13",
+    "vuex": "^3.0.1",
     "webpack": "^2.6.1",
     "webpack-dev-server": "^2.4.5"
   },

--- a/src/__tests__/fixtures/VuexComponent.js
+++ b/src/__tests__/fixtures/VuexComponent.js
@@ -1,0 +1,11 @@
+import Vue from 'vue'
+
+export default Vue.component('vuex-component', {
+  render (h) {
+    return (
+      <ul>
+        {this.$store.state.people.map(p => <li>{p.firstName} {p.lastName}</li>)}
+      </ul>
+    )
+  }
+})

--- a/src/__tests__/fixtures/vuex-store.js
+++ b/src/__tests__/fixtures/vuex-store.js
@@ -1,0 +1,19 @@
+import Vue from 'vue'
+import Vuex from 'vuex'
+
+Vue.use(Vuex)
+
+export default new Vuex.Store({
+  state: {
+    people: [
+      { firstName: 'John', lastName: 'Smith' },
+      { firstName: 'Jane', lastName: 'Doe' }
+    ]
+  },
+
+  mutations: {
+    addPerson (state, person) {
+      state.people = state.people.concat([person])
+    }
+  }
+})

--- a/src/__tests__/vuex.test.js
+++ b/src/__tests__/vuex.test.js
@@ -1,0 +1,76 @@
+import angular from 'angular'
+import Vue from 'vue'
+import store from './fixtures/vuex-store'
+
+import '../plugins'
+
+import ngHtmlCompiler from './utils/ngHtmlCompiler'
+
+import VuexComponent from './fixtures/VuexComponent'
+
+describe('vuex', () => {
+  let $rootScope
+  let $ngVue
+  let compileHTML
+
+  function inject () {
+    angular.mock.inject((_$rootScope_, _$compile_, _$ngVue_) => {
+      $ngVue = _$ngVue_
+
+      $rootScope = _$rootScope_
+      compileHTML = ngHtmlCompiler(_$rootScope_, _$compile_)
+    })
+  }
+
+  beforeEach(() => {
+    angular.mock.module('ngVue')
+    angular.mock.module('ngVue.plugins')
+    angular.mock.module((_$provide_) => {
+      _$provide_.value('VuexComponent', VuexComponent)
+    })
+  })
+
+  describe('initial state', () => {
+    beforeEach(inject)
+
+    it('should not have any Vuex store by default', () => {
+      expect($ngVue.getVuexStore()).toBeUndefined()
+    })
+  })
+
+  describe('active state', () => {
+    beforeEach(() => {
+      angular.mock.module((_$ngVueProvider_) => {
+        _$ngVueProvider_.enableVuex(store)
+      })
+      inject()
+    })
+
+    it('should have a Vuex store', () => {
+      expect($ngVue.getVuexStore()).toEqual(store)
+    })
+
+    it('should render with store data', (done) => {
+      const scope = $rootScope.$new()
+      const elem = compileHTML('<vue-component name="VuexComponent" />', scope)
+      scope.$digest()
+
+      Vue.nextTick(() => {
+        expect(elem[0].innerHTML).toBe('<ul><li>John Smith</li><li>Jane Doe</li></ul>')
+        done()
+      })
+    })
+
+    it('should re-render the component when store changes', (done) => {
+      const scope = $rootScope.$new()
+      const elem = compileHTML('<vue-component name="VuexComponent" />', scope)
+      store.commit('addPerson', {firstName: 'Count', lastName: 'Dracula'})
+
+      scope.$digest()
+      Vue.nextTick(() => {
+        expect(elem[0].innerHTML).toBe('<ul><li>John Smith</li><li>Jane Doe</li><li>Count Dracula</li></ul>')
+        done()
+      })
+    })
+  })
+})

--- a/src/angular/ngVueLinker.js
+++ b/src/angular/ngVueLinker.js
@@ -15,6 +15,7 @@ export function ngVueLinker (componentName, jqElement, elAttributes, scope, $inj
 
   const inQuirkMode = $ngVue ? $ngVue.inQuirkMode() : false
   const vueHooks = $ngVue ? $ngVue.getVueHooks() : {}
+  const vuexStore = $ngVue ? {store: $ngVue.getVuexStore()} : {}
 
   const watchOptions = {
     depth: elAttributes.watchDepth,
@@ -29,7 +30,8 @@ export function ngVueLinker (componentName, jqElement, elAttributes, scope, $inj
     render (h) {
       return <Component {...{ directives }} {...{ props: reactiveData._v }} />
     },
-    ...vueHooks
+    ...vueHooks,
+    ...vuexStore
   })
 
   scope.$on('$destroy', () => {

--- a/src/plugins/provider.js
+++ b/src/plugins/provider.js
@@ -42,9 +42,14 @@ function createVueHooksMap (hookCallback) {
 
 function ngVueProvider ($injector) {
   let inQuirkMode = false
+  let vuexStore
 
   this.activeQuirkMode = () => {
     inQuirkMode = true
+  }
+
+  this.enableVuex = (store) => {
+    vuexStore = store
   }
 
   this.install = (plugin) => {
@@ -74,6 +79,7 @@ function ngVueProvider ($injector) {
 
     return {
       getVueHooks: () => vueHooks,
+      getVuexStore: () => vuexStore,
       inQuirkMode: () => inQuirkMode
     }
   }]


### PR DESCRIPTION
Adding basic support for Vuex is already an improvement to start migrating apps to Vue + Vuex.

Probably this would need further testing to uncover corner cases, but its basic workflow is already covered by unit tests in this PR.

🍺 cheers!