### PR TITLE
Feat/deprecate vattributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,23 +69,23 @@ angular.module('yourApp', ['ngVue'])
 
 ## Features
 
-**ngVue** is composed of a directive `vue-component`, a factory `createVueComponent` and a directive helper `vdirectives`. It also provides some plugins for enhancement.
+**ngVue** is composed of a directive `vue-component`, a factory `createVueComponent` and a directive helper `v-directives`. It also provides some plugins for enhancement.
 
 - `vue-component` is a directive that delegates data to a Vue component so VueJS can compile it with the corresponding nodes
 - `createVueComponent` is a factory that converts a Vue component into a `vue-component` directive
 
 **ngVue** does support VueJS directives but currently they only work with a Vue component in AngularJS templates.
 
-- `vdirectives` is a directive to apply the vue directives to the vue components
+- `v-directives` is a directive to apply the vue directives to the vue components
 
 ```html
 <!-- This won't work -->
-<div vdirectives="hello"></div>
+<div v-directives="hello"></div>
 
 <!-- But this will work ... -->
-<vue-component name="HelloComponent" vdirectives="hello"></vue-component>
+<vue-component name="HelloComponent" v-directives="hello"></vue-component>
 <!-- Or ... -->
-<hello-component vdirectives="hello"></hello-component>
+<hello-component v-directives="hello"></hello-component>
 ```
 
 ### The vue-component directive
@@ -133,7 +133,7 @@ Now you can use `hello-component` in Angular templates:
   <div class="hello-card"
        ng-controller="MainController as ctrl">
     <vue-component name="HelloComponent"
-                   vprops="ctrl.person"
+                   v-props="ctrl.person"
                    watch-depth="value" />
   </div>
 </body>
@@ -143,14 +143,14 @@ The `vue-component` directive provides three main attributes:
 
 - `name` attribute checks for Angular injectable of that name
 
-- `vprops` attribute is a string expression evaluated to an object as the data exposed to Vue component
+- `v-props` attribute is a string expression evaluated to an object as the data exposed to Vue component
 
-- `vprops-*` attribute allows you to name the partial data extracted from the angular scope. `vue-component` wraps them into a new object and pass it to the Vue component. For example `props-first-name` and `props-last-name` will create two properties `firstName` and `lastName` in a new object as the component data
+- `v-props-*` attribute allows you to name the partial data extracted from the angular scope. `vue-component` wraps them into a new object and pass it to the Vue component. For example `props-first-name` and `props-last-name` will create two properties `firstName` and `lastName` in a new object as the component data
 
 ```html
-<vue-component vprops="ctrl.person" />
+<vue-component v-props="ctrl.person" />
 <!-- equals to -->
-<vue-component vprops-first-name="ctrl.person.firstName" vprops-last-name="ctrl.person.lastName" />
+<vue-component v-props-first-name="ctrl.person.firstName" v-props-last-name="ctrl.person.lastName" />
 ```
 
 - `watch-depth` attribute indicates which watch strategy AngularJS will use to detect the changes on the scope objects. The possible values as follows:
@@ -169,7 +169,7 @@ The `vue-component` directive provides three main attributes:
 
 #### Handling events
 
-Events can bubble up from Vue to AngularJS components by binding functions references as `vprops-*`:
+Events can bubble up from Vue to AngularJS components by binding functions references as `v-props-*`:
 
 ```javascript
 app.controller('MainController', function ($scope) {
@@ -181,7 +181,7 @@ app.controller('MainController', function ($scope) {
 ```
 
 ```html
-<vue-component vprops-on-click="ctrl.handleClick"></vue-component>
+<vue-component v-props-on-click="ctrl.handleClick"></vue-component>
 ```
 
 ```javascript

--- a/example/create-vue-component/index.html
+++ b/example/create-vue-component/index.html
@@ -22,7 +22,7 @@
 <body ng-app="vue.components">
   <div class="hello-card"
        ng-controller="MainController as ctrl">
-    <hello-component vprops="ctrl.person"
+    <hello-component v-props="ctrl.person"
                      watch-depth="value"></hello-component>
     <div class="row">
       <div class="col s6">

--- a/example/plugins-filters/index.html
+++ b/example/plugins-filters/index.html
@@ -23,7 +23,7 @@
   <div class="hello-card"
        ng-controller="MainController as ctrl">
     <vue-component name="HelloComponent"
-                   vprops="ctrl.person"
+                   v-props="ctrl.person"
                    watch-depth="value"></vue-component>
     <vue-component name="TagsComponent"></vue-component>
     <div class="row">

--- a/example/vue-component/index.html
+++ b/example/vue-component/index.html
@@ -23,7 +23,7 @@
   <div class="hello-card"
        ng-controller="MainController as ctrl">
     <vue-component name="HelloComponent"
-                   vprops="ctrl.person"
+                   v-props="ctrl.person"
                    watch-depth="value"></vue-component>
     <div class="row">
       <div class="col s6">

--- a/src/__tests__/create-vue-component.test.js
+++ b/src/__tests__/create-vue-component.test.js
@@ -34,20 +34,20 @@ describe('create-vue-component', () => {
       expect(elem[0].innerHTML.replace(/\s/g, '')).toBe('<span>Hello</span>')
     })
 
-    it('should render a vue component with vprops object from scope', () => {
+    it('should render a vue component with v-props object from scope', () => {
       const scope = $rootScope.$new()
       scope.person = { firstName: 'John', lastName: 'Doe' }
-      const elem = compileHTML('<hello vprops="person" />', scope)
+      const elem = compileHTML('<hello v-props="person" />', scope)
       expect(elem[0].innerHTML).toBe('<span>Hello John Doe</span>')
     })
 
-    it('should render a vue component with vprops-name properties from scope', () => {
+    it('should render a vue component with v-props-name properties from scope', () => {
       const scope = $rootScope.$new()
       scope.person = { firstName: 'John', lastName: 'Doe' }
       const elem = compileHTML(
         `<hello
-          vprops-first-name="person.firstName"
-          vprops-last-name="person.lastName" />`,
+          v-props-first-name="person.firstName"
+          v-props-last-name="person.lastName" />`,
         scope
       )
       expect(elem[0].innerHTML).toBe('<span>Hello John Doe</span>')
@@ -60,10 +60,10 @@ describe('create-vue-component', () => {
       $compileProvider.directive('persons', createVueComponent => createVueComponent(PersonsComponent))
     })
 
-    it('should re-render the vue component when vprops value changes', (done) => {
+    it('should re-render the vue component when v-props value changes', (done) => {
       const scope = $rootScope.$new()
       scope.person = { firstName: 'John', lastName: 'Doe' }
-      const elem = compileHTML('<hello vprops="person" />', scope)
+      const elem = compileHTML('<hello v-props="person" />', scope)
 
       scope.person.firstName = 'Jane'
       scope.person.lastName = 'Smith'
@@ -73,10 +73,10 @@ describe('create-vue-component', () => {
       })
     })
 
-    it('should re-render the vue component when vprops reference changes', (done) => {
+    it('should re-render the vue component when v-props reference changes', (done) => {
       const scope = $rootScope.$new()
       scope.person = { firstName: 'John', lastName: 'Doe' }
-      const elem = compileHTML('<hello vprops="person" />', scope)
+      const elem = compileHTML('<hello v-props="person" />', scope)
 
       scope.person = { firstName: 'Jane', lastName: 'Smith' }
       scope.$digest()
@@ -86,13 +86,13 @@ describe('create-vue-component', () => {
       })
     })
 
-    it('should re-render the vue component when vprops-name value change', (done) => {
+    it('should re-render the vue component when v-props-name value change', (done) => {
       const scope = $rootScope.$new()
       scope.person = { firstName: 'John', lastName: 'Doe' }
       const elem = compileHTML(
         `<hello
-          vprops-first-name="person.firstName"
-          vprops-last-name="person.lastName" />`,
+          v-props-first-name="person.firstName"
+          v-props-last-name="person.lastName" />`,
         scope
       )
 
@@ -105,13 +105,13 @@ describe('create-vue-component', () => {
       })
     })
 
-    it('should re-render the vue component when vprops-name reference change', (done) => {
+    it('should re-render the vue component when v-props-name reference change', (done) => {
       const scope = $rootScope.$new()
       scope.person = { firstName: 'John', lastName: 'Doe' }
       const elem = compileHTML(
         `<hello
-          vprops-first-name="person.firstName"
-          vprops-last-name="person.lastName" />`,
+          v-props-first-name="person.firstName"
+          v-props-last-name="person.lastName" />`,
         scope
       )
 
@@ -123,13 +123,13 @@ describe('create-vue-component', () => {
       })
     })
 
-    it('should re-render the vue component when vprops-name is an array and its items change', (done) => {
+    it('should re-render the vue component when v-props-name is an array and its items change', (done) => {
       const scope = $rootScope.$new()
       scope.persons = [
         { firstName: 'John', lastName: 'Doe' },
         { firstName: 'Jane', lastName: 'Doe' }
       ]
-      const elem = compileHTML(`<persons vprops-persons="persons" />`, scope)
+      const elem = compileHTML(`<persons v-props-persons="persons" />`, scope)
 
       // use Array.prototype.splice
       scope.persons.splice(0, 1, { firstName: 'John', lastName: 'Smith' })

--- a/src/__tests__/quirk-mode.test.js
+++ b/src/__tests__/quirk-mode.test.js
@@ -47,7 +47,7 @@ describe('quirk mode', () => {
       const elem = compileHTML(
         `<vue-component
           name="PersonsComponent"
-          vprops-persons="persons" />`,
+          v-props-persons="persons" />`,
         scope
       )
 
@@ -66,7 +66,7 @@ describe('quirk mode', () => {
       const elem = compileHTML(
         `<vue-component
           name="HelloComponent"
-          vprops="person"
+          v-props="person"
           watch-depth="value" />`,
         scope
       )
@@ -102,7 +102,7 @@ describe('quirk mode', () => {
       const elem = compileHTML(
         `<vue-component
           name="PersonsComponent"
-          vprops-persons="persons"
+          v-props-persons="persons"
           watch-depth="collection" />`,
         scope
       )
@@ -122,7 +122,7 @@ describe('quirk mode', () => {
       const elem = compileHTML(
         `<vue-component
           name="HelloComponent"
-          vprops="person"
+          v-props="person"
           watch-depth="value" />`,
         scope
       )

--- a/src/__tests__/vue-component.test.js
+++ b/src/__tests__/vue-component.test.js
@@ -34,21 +34,21 @@ describe('vue-component', () => {
       expect(elem[0].innerHTML.replace(/\s/g, '')).toBe('<span>Hello</span>')
     })
 
-    it('should render a vue component with vprops object from scope', () => {
+    it('should render a vue component with v-props object from scope', () => {
       const scope = $rootScope.$new()
       scope.person = { firstName: 'John', lastName: 'Doe' }
-      const elem = compileHTML('<vue-component name="HelloComponent" vprops="person" />', scope)
+      const elem = compileHTML('<vue-component name="HelloComponent" v-props="person" />', scope)
       expect(elem[0].innerHTML).toBe('<span>Hello John Doe</span>')
     })
 
-    it('should render a vue component with vprops-name properties from scope', () => {
+    it('should render a vue component with v-props-name properties from scope', () => {
       const scope = $rootScope.$new()
       scope.person = { firstName: 'John', lastName: 'Doe' }
       const elem = compileHTML(
         `<vue-component
           name="HelloComponent"
-          vprops-first-name="person.firstName"
-          vprops-last-name="person.lastName" />`,
+          v-props-first-name="person.firstName"
+          v-props-last-name="person.lastName" />`,
         scope
       )
       expect(elem[0].innerHTML).toBe('<span>Hello John Doe</span>')
@@ -61,10 +61,10 @@ describe('vue-component', () => {
       $provide.value('PersonsComponent', PersonsComponent)
     })
 
-    it('should re-render the vue component when vprops value changes', (done) => {
+    it('should re-render the vue component when v-props value changes', (done) => {
       const scope = $rootScope.$new()
       scope.person = { firstName: 'John', lastName: 'Doe' }
-      const elem = compileHTML('<vue-component name="HelloComponent" vprops="person" />', scope)
+      const elem = compileHTML('<vue-component name="HelloComponent" v-props="person" />', scope)
 
       scope.person.firstName = 'Jane'
       scope.person.lastName = 'Smith'
@@ -74,10 +74,10 @@ describe('vue-component', () => {
       })
     })
 
-    it('should re-render the vue component when vprops reference changes', (done) => {
+    it('should re-render the vue component when v-props reference changes', (done) => {
       const scope = $rootScope.$new()
       scope.person = { firstName: 'John', lastName: 'Doe' }
-      const elem = compileHTML('<vue-component name="HelloComponent" vprops="person" />', scope)
+      const elem = compileHTML('<vue-component name="HelloComponent" v-props="person" />', scope)
 
       scope.person = { firstName: 'Jane', lastName: 'Smith' }
       scope.$digest()
@@ -87,14 +87,14 @@ describe('vue-component', () => {
       })
     })
 
-    it('should re-render the vue component when vprops-name value change', (done) => {
+    it('should re-render the vue component when v-props-name value change', (done) => {
       const scope = $rootScope.$new()
       scope.person = { firstName: 'John', lastName: 'Doe' }
       const elem = compileHTML(
         `<vue-component
           name="HelloComponent"
-          vprops-first-name="person.firstName"
-          vprops-last-name="person.lastName" />`,
+          v-props-first-name="person.firstName"
+          v-props-last-name="person.lastName" />`,
         scope
       )
 
@@ -107,14 +107,14 @@ describe('vue-component', () => {
       })
     })
 
-    it('should re-render the vue component when vprops-name reference change', (done) => {
+    it('should re-render the vue component when v-props-name reference change', (done) => {
       const scope = $rootScope.$new()
       scope.person = { firstName: 'John', lastName: 'Doe' }
       const elem = compileHTML(
         `<vue-component
           name="HelloComponent"
-          vprops-first-name="person.firstName"
-          vprops-last-name="person.lastName" />`,
+          v-props-first-name="person.firstName"
+          v-props-last-name="person.lastName" />`,
         scope
       )
 
@@ -126,7 +126,7 @@ describe('vue-component', () => {
       })
     })
 
-    it('should re-render the vue component when vprops-name is an array and its items change', (done) => {
+    it('should re-render the vue component when v-props-name is an array and its items change', (done) => {
       const scope = $rootScope.$new()
       scope.persons = [
         { firstName: 'John', lastName: 'Doe' },
@@ -135,7 +135,7 @@ describe('vue-component', () => {
       const elem = compileHTML(
         `<vue-component
           name="PersonsComponent"
-          vprops-persons="persons" />`,
+          v-props-persons="persons" />`,
         scope
       )
 

--- a/src/components/props/getExpressions.js
+++ b/src/components/props/getExpressions.js
@@ -10,8 +10,8 @@ import extractExpressionName from './extractPropName'
  * @returns {Object|string|null}
  */
 export function extractExpressions (exprType, attributes) {
-  const objectExprKey = exprType === 'props' ? 'vprops' : 'vdata'
-  const objectPropExprRegExp = exprType === 'props' ? /vprops/i : /vdata/i
+  const objectExprKey = exprType === 'props' ? 'vProps' : 'vData'
+  const objectPropExprRegExp = exprType === 'props' ? /vProps/i : /vData/i
 
   const objectExpr = attributes[objectExprKey]
 

--- a/src/components/props/watchExpressions.js
+++ b/src/components/props/watchExpressions.js
@@ -3,13 +3,13 @@ import Vue from 'vue'
 
 function watch (expressions, reactiveData) {
   return (watchFunc) => {
-    // for `vprops` / `vdata`
+    // for `v-props` / `v-data`
     if (isString(expressions)) {
       watchFunc(expressions, Vue.set.bind(Vue, reactiveData, '_v'))
       return
     }
 
-    // for `vprops-something`
+    // for `v-props-something`
     Object.keys(expressions)
       .forEach((name) => {
         watchFunc(expressions[name], Vue.set.bind(Vue, reactiveData._v, name))

--- a/src/directives/evaluateDirectives.js
+++ b/src/directives/evaluateDirectives.js
@@ -12,17 +12,17 @@ const transformers = {
 
 /**
  *
- * vdirectives:
+ * v-directives:
  *  - Array: [{name: string, value: *, modifiers: Object, params: Object}]
  *  - Object: {name: string, value: *, modifiers: Object, params: Object}
  *  - String: a single directive name or multi-directive names separated with a comma
  *
- * @param attributes {{vdirectives: string|undefined}}
+ * @param attributes {{vDirectives: string|undefined}}
  * @param scope
  * @returns {Array|null}
  */
 export default function evaluateDirectives (attributes, scope) {
-  const directivesExpr = attributes.vdirectives
+  const directivesExpr = attributes.vDirectives
 
   if (angular.isUndefined(directivesExpr)) {
     return null

--- a/src/index.js
+++ b/src/index.js
@@ -19,9 +19,9 @@ import { ngVueLinker } from './angular/ngVueLinker'
  *    return vueComponentFactory('hello')
  *  })
  *
- * <hello-component vprops="person"></hello-component>
+ * <hello-component v-props="person"></hello-component>
  *
- * <hello-component vprops-first-name="person.firstName" vprops-last-name="person.lastName"></hello-component>
+ * <hello-component v-props-first-name="person.firstName" v-props-last-name="person.lastName"></hello-component>
  *
  * @param $injector
  * @returns {Function}
@@ -40,7 +40,7 @@ function ngVueComponentFactory ($injector) {
 }
 
 /**
- * <vue-component name="HelloComponent" vprops="person"></vue-component>
+ * <vue-component name="HelloComponent" v-props="person"></vue-component>
  *
  * @param $injector
  * @returns {{restrict: string, link: (function(*=, *=, *=))}}


### PR DESCRIPTION
This PR deprecates `vprops`, `vdata` and `vdirectives` attributes in favor of `v-props`, `v-data`, `v-directives` to stick with something more native with Vue (`v-bind:`, `v-on:`).