### PR TITLE
Feat/support html attributes

### DIFF
--- a/src/__tests__/create-vue-component.test.js
+++ b/src/__tests__/create-vue-component.test.js
@@ -4,6 +4,7 @@ import Vue from 'vue'
 import ngHtmlCompiler from './utils/ngHtmlCompiler'
 
 import HelloComponent from './fixtures/HelloComponent'
+import HelloWrappedComponent from './fixtures/HelloWrappedComponent'
 import PersonsComponent from './fixtures/PersonsComponent'
 import ButtonComponent from './fixtures/ButtonComponent'
 import GreetingsComponent from './fixtures/GreetingsComponent'
@@ -64,6 +65,18 @@ describe('create-vue-component', () => {
           data-qa="'John'" />`
       )
       expect(elem[0].innerHTML).toBe('<span random="hello" tabindex="1" disabled="disabled" data-qa="John">Hello  </span>')
+    })
+
+    it('should render a vue component with original html attributes on elements that bind $attrs ', () => {
+      $compileProvider.directive('helloWrapped', createVueComponent => createVueComponent(HelloWrappedComponent))
+      const elem = compileHTML(
+        `<hello-wrapped
+          random="'hello'"
+          tabindex="1"
+          disabled
+          data-qa="'John'" />`
+      )
+      expect(elem[0].innerHTML).toBe('<div><span random="hello" tabindex="1" disabled="disabled" data-qa="John">Hello  </span></div>')
     })
   })
 

--- a/src/__tests__/create-vue-component.test.js
+++ b/src/__tests__/create-vue-component.test.js
@@ -54,6 +54,17 @@ describe('create-vue-component', () => {
       )
       expect(elem[0].innerHTML).toBe('<span>Hello John Doe</span>')
     })
+
+    it('should render a vue component with original html attributes ', () => {
+      const elem = compileHTML(
+        `<hello
+          random="'hello'"
+          tabindex="1"
+          disabled
+          data-qa="'John'" />`
+      )
+      expect(elem[0].innerHTML).toBe('<span random="hello" tabindex="1" disabled="disabled" data-qa="John">Hello  </span>')
+    })
   })
 
   describe('update', () => {
@@ -141,6 +152,27 @@ describe('create-vue-component', () => {
       scope.$digest()
       Vue.nextTick(() => {
         expect(elem[0].innerHTML).toBe('<ul><li>John Smith</li><li>Jane Smith</li></ul>')
+        done()
+      })
+    })
+
+    it('should re-render a vue component with attribute values change', (done) => {
+      const scope = $rootScope.$new()
+      scope.isDisabled = false
+      scope.tabindex = 0
+      scope.randomAttr = "enabled"
+      const elem = compileHTML(
+        `<hello random="randomAttr" tabindex="tabindex" disabled="isDisabled" />`,
+        scope
+      )
+      expect(elem[0].innerHTML).toBe('<span random="enabled" tabindex="0">Hello  </span>')
+
+      scope.isDisabled = true
+      scope.tabindex = 1
+      scope.randomAttr = "disabled"
+      scope.$digest()
+      Vue.nextTick(() => {
+        expect(elem[0].innerHTML).toBe('<span random="disabled" tabindex="1" disabled="disabled">Hello  </span>')
         done()
       })
     })

--- a/src/__tests__/fixtures/HelloWrappedComponent.js
+++ b/src/__tests__/fixtures/HelloWrappedComponent.js
@@ -1,0 +1,13 @@
+import Vue from 'vue'
+import HelloComponent from './HelloComponent'
+
+export default Vue.component('hello-wrapped-component', {
+  inheritAttrs: false,
+  render (h) {
+    return (
+      <div>
+        <HelloComponent {...{attrs: this.$attrs}}/>
+      </div>
+    )
+  }
+})

--- a/src/__tests__/vue-component.test.js
+++ b/src/__tests__/vue-component.test.js
@@ -55,6 +55,18 @@ describe('vue-component', () => {
       )
       expect(elem[0].innerHTML).toBe('<span>Hello John Doe</span>')
     })
+
+    it('should render a vue component with original html attributes ', () => {
+      const elem = compileHTML(
+        `<vue-component
+          name="HelloComponent"
+          random="'hello'"
+          tabindex="1"
+          disabled
+          data-qa="'John'" />`
+      )
+      expect(elem[0].innerHTML).toBe('<span random="hello" tabindex="1" disabled="disabled" data-qa="John">Hello  </span>')
+    })
   })
 
   describe('update', () => {
@@ -149,6 +161,31 @@ describe('vue-component', () => {
       scope.$digest()
       Vue.nextTick(() => {
         expect(elem[0].innerHTML).toBe('<ul><li>John Smith</li><li>Jane Smith</li></ul>')
+        done()
+      })
+    })
+
+    it('should re-render a vue component with attribute values change', (done) => {
+      const scope = $rootScope.$new()
+      scope.isDisabled = false
+      scope.tabindex = 0
+      scope.randomAttr = "enabled"
+      const elem = compileHTML(
+        `<vue-component
+          name="HelloComponent"
+          random="randomAttr"
+          tabindex="tabindex"
+          disabled="isDisabled" />`,
+        scope
+      )
+      expect(elem[0].innerHTML).toBe('<span random="enabled" tabindex="0">Hello  </span>')
+
+      scope.isDisabled = true
+      scope.tabindex = 1
+      scope.randomAttr = "disabled"
+      scope.$digest()
+      Vue.nextTick(() => {
+        expect(elem[0].innerHTML).toBe('<span random="disabled" tabindex="1" disabled="disabled">Hello  </span>')
         done()
       })
     })

--- a/src/__tests__/vue-component.test.js
+++ b/src/__tests__/vue-component.test.js
@@ -4,6 +4,7 @@ import Vue from 'vue'
 import ngHtmlCompiler from './utils/ngHtmlCompiler'
 
 import HelloComponent from './fixtures/HelloComponent'
+import HelloWrappedComponent from './fixtures/HelloWrappedComponent'
 import PersonsComponent from './fixtures/PersonsComponent'
 import ButtonComponent from './fixtures/ButtonComponent'
 import GreetingsComponent from './fixtures/GreetingsComponent'
@@ -66,6 +67,19 @@ describe('vue-component', () => {
           data-qa="'John'" />`
       )
       expect(elem[0].innerHTML).toBe('<span random="hello" tabindex="1" disabled="disabled" data-qa="John">Hello  </span>')
+    })
+
+    it('should render a vue component with original html attributes on elements that bind $attrs ', () => {
+      $provide.value('HelloWrappedComponent', HelloWrappedComponent)
+      const elem = compileHTML(
+        `<vue-component
+          name="HelloWrappedComponent"
+          random="'hello'"
+          tabindex="1"
+          disabled
+          data-qa="'John'" />`
+      )
+      expect(elem[0].innerHTML).toBe('<div><span random="hello" tabindex="1" disabled="disabled" data-qa="John">Hello  </span></div>')
     })
   })
 

--- a/src/angular/ngVueLinker.js
+++ b/src/angular/ngVueLinker.js
@@ -51,7 +51,7 @@ export function ngVueLinker (componentName, jqElement, elAttributes, scope, $inj
     data: reactiveData,
     render (h) {
       return (
-        <Component {...{ directives }} {...{ props: reactiveData._v, on }}>
+        <Component {...{ directives }} {...{ props: reactiveData._v.props, on, attrs: reactiveData._v.attrs }}>
           { <span ref="__slot__" /> }
         </Component>
       )

--- a/src/angular/ngVueLinker.js
+++ b/src/angular/ngVueLinker.js
@@ -3,7 +3,7 @@ import Vue from 'vue'
 import getVueComponent from '../components/getVueComponent'
 import getPropExprs from '../components/props/getExpressions'
 import watchPropExprs from '../components/props/watchExpressions'
-import evalPropValues from '../components/props/evaluateValues'
+import evalValues from '../components/props/evaluateValues'
 import evalPropEvents from '../components/props/evaluateEvents'
 import evaluateDirectives from '../directives/evaluateDirectives'
 
@@ -14,7 +14,12 @@ export function ngVueLinker (componentName, jqElement, elAttributes, scope, $inj
   const dataExprsMap = getPropExprs(elAttributes)
   const Component = getVueComponent(componentName, $injector)
   const directives = evaluateDirectives(elAttributes, scope) || []
-  const reactiveData = { _v: evalPropValues(dataExprsMap, scope) || {} }
+  const reactiveData = {
+    _v: {
+      props: evalValues(dataExprsMap.props || dataExprsMap.data, scope) || {},
+      attrs: evalValues(dataExprsMap.htmlAttributes, scope) || {}
+    }
+  }
   const on = evalPropEvents(dataExprsMap, scope) || {}
 
   const inQuirkMode = $ngVue ? $ngVue.inQuirkMode() : false

--- a/src/angular/ngVueLinker.js
+++ b/src/angular/ngVueLinker.js
@@ -43,8 +43,8 @@ export function ngVueLinker (componentName, jqElement, elAttributes, scope, $inj
     depth: elAttributes.watchDepth,
     quirk: inQuirkMode
   }
-  watchPropExprs(dataExprsMap, reactiveData, watchOptions, scope)
-
+  watchPropExprs(dataExprsMap, reactiveData, watchOptions, scope, 'props')
+  watchPropExprs(dataExprsMap, reactiveData, watchOptions, scope, 'attrs')
   const vueInstance = new Vue({
     name: 'NgVue',
     el: jqElement[0],

--- a/src/components/props/evaluateValues.js
+++ b/src/components/props/evaluateValues.js
@@ -1,16 +1,11 @@
 import angular from 'angular'
 
 /**
- * @param dataExprsMap Object
- * @param dataExprsMap.data Object|string|null
- * @param dataExprsMap.props Object|string|null
+ * @param expr Object|string|null
  * @param scope Object
  * @returns {string|Object|null}
  */
-export default function evaluateValues (dataExprsMap, scope) {
-  const key = dataExprsMap.props ? 'props' : 'data'
-  const expr = dataExprsMap[key]
-
+export default function evaluateValues (expr, scope) {
   if (!expr) {
     return null
   }

--- a/src/components/props/extractHtmlAttributes.js
+++ b/src/components/props/extractHtmlAttributes.js
@@ -1,0 +1,14 @@
+/**
+ * @param attributes Object
+ * @returns {Array} Array of attributes that pass the filter
+ */
+export default function extractHtmlAttributes (attributes) {
+  // Filter out everything except for HTML attributes, e.g. tabindex, disabled
+  return Object.keys(attributes)
+    .filter(attr => {
+      const isSpecialAttr = /^(vProps|vData|vOn|vDirectives|watchDepth|ng)/i.test(attr)
+      const isJqliteProperty = attr[0] === '$'
+      // Vue does not consider class or style as an attr
+      return !isSpecialAttr && !isJqliteProperty && attr !== "class" && attr !== "style"
+    })
+}

--- a/src/components/props/getExpressions.js
+++ b/src/components/props/getExpressions.js
@@ -39,14 +39,22 @@ export function extractExpressions (exprType, attributes) {
 
   const exprsMap = {/* name : expression */}
   expressions.forEach((attrExprName) => {
-    let exprName
     if (objectExprKey) {
-      exprName = extractExpressionName(attrExprName, objectExprKey)
+      const exprName = extractExpressionName(attrExprName, objectExprKey)
+      exprsMap[exprName] = attributes[attrExprName]
     } else {
       // Non-prefixed attributes, i.e. a regular HTML attribute
-      exprName = attrExprName
+      // Get original attribute name from $attr not stripped by Angular, e.g. data-qa and not qa
+      const attrName = attributes.$attr[attrExprName]
+      let attrValue
+      // Handle attributes with no value, e.g. <button disabled></button>
+      if (attributes[attrExprName] === '') {
+        attrValue = `'${attrExprName}'`
+      } else {
+        attrValue = attributes[attrExprName]
+      }
+      exprsMap[attrName] = attrValue
     }
-    exprsMap[exprName] = attributes[attrExprName]
   })
 
   return exprsMap

--- a/src/components/props/getExpressions.js
+++ b/src/components/props/getExpressions.js
@@ -1,10 +1,11 @@
 import angular from 'angular'
 import extractExpressionName from './extractPropName'
+import extractHtmlAttributes from './extractHtmlAttributes'
 
 /**
- * Extract the property/data expressions from the element attribute.
+ * Extract a subset of expressions from the element attributes, e.g. property/data, on, or htmlAttribute
  *
- * @param exprType 'props'|'data'|'on'
+ * @param exprType 'props'|'data'|'on'|'htmlAttributes'
  * @param attributes Object
  *
  * @returns {Object|string|null}
@@ -24,8 +25,13 @@ export function extractExpressions (exprType, attributes) {
     return objectExpr
   }
 
-  const expressions = Object.keys(attributes)
-    .filter((attr) => objectPropExprRegExp.test(attr))
+  let expressions
+  if (exprType === 'htmlAttributes') {
+    expressions = extractHtmlAttributes(attributes)
+  } else {
+    expressions = Object.keys(attributes)
+      .filter((attr) => objectPropExprRegExp.test(attr))
+  }
 
   if (expressions.length === 0) {
     return null
@@ -33,7 +39,13 @@ export function extractExpressions (exprType, attributes) {
 
   const exprsMap = {/* name : expression */}
   expressions.forEach((attrExprName) => {
-    const exprName = extractExpressionName(attrExprName, objectExprKey)
+    let exprName
+    if (objectExprKey) {
+      exprName = extractExpressionName(attrExprName, objectExprKey)
+    } else {
+      // Non-prefixed attributes, i.e. a regular HTML attribute
+      exprName = attrExprName
+    }
     exprsMap[exprName] = attributes[attrExprName]
   })
 
@@ -48,6 +60,7 @@ export default function getExpressions (attributes) {
   return {
     data: extractExpressions('data', attributes),
     props: extractExpressions('props', attributes),
-    events: extractExpressions('on', attributes)
+    events: extractExpressions('on', attributes),
+    htmlAttributes: extractExpressions('htmlAttributes', attributes)
   }
 }

--- a/src/components/props/watchExpressions.js
+++ b/src/components/props/watchExpressions.js
@@ -50,6 +50,7 @@ function notify (setter, inQuirkMode) {
  * @param options.depth 'reference'|'value'|'collection'
  * @param options.quirk 'reference'|'value'|'collection'
  * @param scope Object
+ * @param type String 'props'|'attrs'
  */
 export default function watchExpressions (dataExprsMap, reactiveData, options, scope, type) {
   let expressions

--- a/src/components/props/watchExpressions.js
+++ b/src/components/props/watchExpressions.js
@@ -1,18 +1,18 @@
 import {isString, isArray, isObject} from 'angular'
 import Vue from 'vue'
 
-function watch (expressions, reactiveData) {
+function watch (expressions, reactiveData, type) {
   return (watchFunc) => {
     // for `v-props` / `v-data`
     if (isString(expressions)) {
-      watchFunc(expressions, Vue.set.bind(Vue, reactiveData, '_v'))
+      watchFunc(expressions, Vue.set.bind(Vue, reactiveData._v, type))
       return
     }
 
     // for `v-props-something`
     Object.keys(expressions)
       .forEach((name) => {
-        watchFunc(expressions[name], Vue.set.bind(Vue, reactiveData._v, name))
+        watchFunc(expressions[name], Vue.set.bind(Vue, reactiveData._v[type], name))
       })
   }
 }
@@ -51,15 +51,20 @@ function notify (setter, inQuirkMode) {
  * @param options.quirk 'reference'|'value'|'collection'
  * @param scope Object
  */
-export default function watchExpressions (dataExprsMap, reactiveData, options, scope) {
-  const expressions = dataExprsMap.props ? dataExprsMap.props : dataExprsMap.data
+export default function watchExpressions (dataExprsMap, reactiveData, options, scope, type) {
+  let expressions
+  if (type === 'props') {
+    expressions = dataExprsMap.props ? dataExprsMap.props : dataExprsMap.data
+  } else if (type === 'attrs') {
+    expressions = dataExprsMap.htmlAttributes
+  }
 
   if (!expressions) {
     return
   }
 
   const { depth, quirk } = options
-  const watcher = watch(expressions, reactiveData)
+  const watcher = watch(expressions, reactiveData, type)
 
   switch (depth) {
     case 'value':


### PR DESCRIPTION
### Description
This pull requests adds support for passing down regular HTML attributes like `tabindex` and `disabled` from the `ngVue` component to the Vue root element. Please see original issue described in #60 for an example.

### Todos
- [x] regular attributes (`<button tabindex="1"></button>`)
- [x] attributes without values (`<button disabled></button>`)
- [x] updating value based on scope changes  (`<button tabindex="ctrl.myTabindex"></button>`)
- [x] support `data-` attributes (Angular [normalizes them and strips the data- part out](https://docs.angularjs.org/guide/directive#matching-directives) by default)
- [x] ensure that `inheritAttrs: false` and binding `$attrs` to a non-root element works
- [x] add unit tests
- [ ] update docs

### Notes
In working on this PR, I noticed a few places that check for either `vProps` or `vData`, but as far as I could tell, `vData` is just an alias. Is it needed? If not, I think the code could be cleaned up a bit and some of the utility functions like `getExpressions/watchExpressions` and `if/else` blocks could be simplified. Let me know! If `vData` isn't needed, I'm happy to remove it and refactor.