### PR TITLE
Fix #63 Release vueInstance to memory

### DIFF
--- a/src/angular/ngVueLinker.js
+++ b/src/angular/ngVueLinker.js
@@ -57,7 +57,7 @@ export function ngVueLinker (componentName, jqElement, elAttributes, scope, $inj
 
   scope.$on('$destroy', () => {
     vueInstance.$destroy()
-    vueInstance.$el.remove()
+    angular.element(vueInstance.$el).remove()
     vueInstance = null
   })
 }

--- a/src/angular/ngVueLinker.js
+++ b/src/angular/ngVueLinker.js
@@ -58,5 +58,6 @@ export function ngVueLinker (componentName, jqElement, elAttributes, scope, $inj
   scope.$on('$destroy', () => {
     vueInstance.$destroy()
     vueInstance.$el.remove()
+    vueInstance = null
   })
 }


### PR DESCRIPTION
From my issue:

I want to set the vueInstance to null when the scope is destroyed. This will allow it to be released to memory.

I will also suggest to use angular.element().remove() to remove the $el element. Since Angular uses jQlite (or JQuery), it caches information of various elements in the DOM. That cached data only gets released if the proper jQuery remove method is called.