### PR TITLE
Support passing class and style attributes down to Vue component.

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ const VComponent = Vue.component('hello-component', {
 ### Handling HTML attributes
 
 Just like regular Vue components, you can pass HTML attributes from the parent Angular component to your Vue component.
-Keep in mind that when you pass down literal strings, they must be surrounded by quotes, e.g. `data-value="'enabled'"`
+The parent's `class` and `style` attributes will be merged with the corresponding Vue component attributes, while others will be passed down unless they conflict with attributes in the Vue component's own template.
+Keep in mind that when you pass down literal strings for anything other than `class` and `style` attributes, they must be surrounded by quotes, e.g. `data-value="'enabled'"`.
 
 ```javascript
 angular.module("app")
@@ -213,6 +214,7 @@ angular.module("app")
 ```html
 <my-custom-button
   disabled="ctrl.isDisabled"
+  class="excellent"
   tabindex="3"
   type="'submit'"
   v-props-button-text="'Click me'" />
@@ -220,7 +222,7 @@ angular.module("app")
 
 ```vue
 <template>
-<!-- tabindex, type, and disabled will appear on the button element -->
+<!-- tabindex, type, class, and disabled will appear on the button element -->
 <button>
   {{ buttonText }}
 </button>

--- a/src/__tests__/create-vue-component.test.js
+++ b/src/__tests__/create-vue-component.test.js
@@ -61,10 +61,12 @@ describe('create-vue-component', () => {
         `<hello
           random="'hello'"
           tabindex="1"
+          class="foo"
+          style="font-size: 2em;"
           disabled
           data-qa="'John'" />`
       )
-      expect(elem[0].innerHTML).toBe('<span random="hello" tabindex="1" disabled="disabled" data-qa="John">Hello  </span>')
+      expect(elem[0].innerHTML).toBe('<span random="hello" tabindex="1" disabled="disabled" data-qa="John" class="foo" style="font-size: 2em;">Hello  </span>')
     })
 
     it('should render a vue component with original html attributes on elements that bind $attrs ', () => {
@@ -73,10 +75,12 @@ describe('create-vue-component', () => {
         `<hello-wrapped
           random="'hello'"
           tabindex="1"
+          class="foo"
+          style="font-size: 2em;"
           disabled
           data-qa="'John'" />`
       )
-      expect(elem[0].innerHTML).toBe('<div><span random="hello" tabindex="1" disabled="disabled" data-qa="John">Hello  </span></div>')
+      expect(elem[0].innerHTML).toBe('<div class="foo" style="font-size: 2em;"><span random="hello" tabindex="1" disabled="disabled" data-qa="John">Hello  </span></div>')
     })
   })
 
@@ -174,19 +178,28 @@ describe('create-vue-component', () => {
       scope.isDisabled = false
       scope.tabindex = 0
       scope.randomAttr = "enabled"
+      scope.class = 'foo'
+      scope.size = '2em'
       const elem = compileHTML(
-        `<hello random="randomAttr" tabindex="tabindex" disabled="isDisabled" />`,
+        `<hello random="randomAttr" tabindex="tabindex" disabled="isDisabled" class="{{class}}" ng-style="{'font-size': size}"/>`,
         scope
       )
-      expect(elem[0].innerHTML).toBe('<span random="enabled" tabindex="0">Hello  </span>')
+      $rootScope.$digest()  // extra full digest needed for $animate to apply new class
 
-      scope.isDisabled = true
-      scope.tabindex = 1
-      scope.randomAttr = "disabled"
-      scope.$digest()
-      Vue.nextTick(() => {
-        expect(elem[0].innerHTML).toBe('<span random="disabled" tabindex="1" disabled="disabled">Hello  </span>')
-        done()
+      Vue.nextTick(() => {  // wait a tick for ng-* directives' settled values to propagate
+        expect(elem[0].innerHTML).toBe('<span random="enabled" tabindex="0" class="foo" style="font-size: 2em;">Hello  </span>')
+
+        scope.isDisabled = true
+        scope.tabindex = 1
+        scope.randomAttr = "disabled"
+        scope.class = 'bar'
+        scope.size = '3em'
+        scope.$digest()
+        $rootScope.$digest()  // extra full digest needed for $animate to apply new class
+        Vue.nextTick(() => {
+          expect(elem[0].innerHTML).toBe('<span random="disabled" tabindex="1" class="bar" style="font-size: 3em;" disabled="disabled">Hello  </span>')
+          done()
+        })
       })
     })
   })

--- a/src/__tests__/vue-component.test.js
+++ b/src/__tests__/vue-component.test.js
@@ -63,10 +63,12 @@ describe('vue-component', () => {
           name="HelloComponent"
           random="'hello'"
           tabindex="1"
+          class="foo"
+          style="font-size: 2em;"
           disabled
           data-qa="'John'" />`
       )
-      expect(elem[0].innerHTML).toBe('<span random="hello" tabindex="1" disabled="disabled" data-qa="John">Hello  </span>')
+      expect(elem[0].innerHTML).toBe('<span random="hello" tabindex="1" disabled="disabled" data-qa="John" class="foo" style="font-size: 2em;">Hello  </span>')
     })
 
     it('should render a vue component with original html attributes on elements that bind $attrs ', () => {
@@ -76,10 +78,12 @@ describe('vue-component', () => {
           name="HelloWrappedComponent"
           random="'hello'"
           tabindex="1"
+          class="foo"
+          style="font-size: 2em;"
           disabled
           data-qa="'John'" />`
       )
-      expect(elem[0].innerHTML).toBe('<div><span random="hello" tabindex="1" disabled="disabled" data-qa="John">Hello  </span></div>')
+      expect(elem[0].innerHTML).toBe('<div class="foo" style="font-size: 2em;"><span random="hello" tabindex="1" disabled="disabled" data-qa="John">Hello  </span></div>')
     })
   })
 
@@ -184,23 +188,35 @@ describe('vue-component', () => {
       scope.isDisabled = false
       scope.tabindex = 0
       scope.randomAttr = "enabled"
+      scope.class = 'foo'
+      scope.size = '2em'
       const elem = compileHTML(
         `<vue-component
           name="HelloComponent"
           random="randomAttr"
           tabindex="tabindex"
+          class="{{class}}"
+          ng-style="{'font-size': size}"
           disabled="isDisabled" />`,
         scope
       )
-      expect(elem[0].innerHTML).toBe('<span random="enabled" tabindex="0">Hello  </span>')
+      $rootScope.$digest()  // extra full digest needed for $animate to apply new class
 
-      scope.isDisabled = true
-      scope.tabindex = 1
-      scope.randomAttr = "disabled"
-      scope.$digest()
-      Vue.nextTick(() => {
-        expect(elem[0].innerHTML).toBe('<span random="disabled" tabindex="1" disabled="disabled">Hello  </span>')
-        done()
+      Vue.nextTick(() => {  // wait a tick for ng-* directives' settled values to propagate
+        expect(elem[0].innerHTML).toBe('<span random="enabled" tabindex="0" class="foo" style="font-size: 2em;">Hello  </span>')
+
+        scope.isDisabled = true
+        scope.tabindex = 1
+        scope.randomAttr = "disabled"
+        scope.class = 'bar'
+        scope.size = '3em'
+        scope.$digest()
+        $rootScope.$digest()  // extra full digest needed for $animate to apply new class
+
+        Vue.nextTick(() => {
+          expect(elem[0].innerHTML).toBe('<span random="disabled" tabindex="1" class="bar" style="font-size: 3em;" disabled="disabled">Hello  </span>')
+          done()
+        })
       })
     })
   })

--- a/src/components/props/extractSpecialAttributes.js
+++ b/src/components/props/extractSpecialAttributes.js
@@ -1,0 +1,10 @@
+const SPECIAL_ATTRIBUTE_KEYS = ['class', 'style']
+
+export default function extractSpecialAttributes (attributes) {
+  const specialAttributes = {/* name: value */}
+  SPECIAL_ATTRIBUTE_KEYS.forEach(key => {
+    const value = attributes[key]
+    if (value || attributes[attributes.$normalize(`ng-${key}`)]) specialAttributes[key] = value
+  })
+  return specialAttributes
+}

--- a/src/components/props/observeAttributes.js
+++ b/src/components/props/observeAttributes.js
@@ -1,0 +1,11 @@
+import Vue from 'vue'
+
+export default function observeAttributes (reactiveData, element, scope, type) {
+  Object.keys(reactiveData._v[type]).forEach(key => {
+    // Use scope.$watch instead of attrs.$observe because we want to catch changes in attribute
+    // value that don't necessarily come directly from interpolation.
+    scope.$watch(() => element.attr(key), newValue => {
+      Vue.set(reactiveData._v[type], key, newValue)
+    })
+  })
+}


### PR DESCRIPTION
Works with static values, interpolated values, and `ng-class` and `ng-style`.  It won't work with any other directives that happen to modify these attributes but I figured that would be exceedingly rare and we can save on unnecessary watchers this way.

Fixes #67.
