### PR TITLE
fix($ngVueProvider): Inject root vue instance props

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -164,7 +164,7 @@ import store from './store'
 
 angular.module('yourApp', ['ngVue', 'ngVue.plugins'])
   .config(($ngVueProvider) => {
-		$ngVueProvider.enableVuex(store)
+		$ngVueProvider.setRootVueInstanceProps({store: store})
 	})
 ```
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2,26 +2,31 @@
 
 > this is an experimental feature and still under development
 
-What if I want to use Angular filters in VueJS templates? Is it possible to use vuex to manage the state? How can I reuse the business code in VueJS when the application is too deep into Angular 1.x? ... 
+What if I want to use Angular filters in Vue.js templates? Is it possible to use Vuex to manage the state? How can I reuse 
+the business code in Vue.js when the application is too deep into Angular 1.x? ... 
 
-There are more complicated problems when we try to integrate Angular 1.x with VueJS. It is impossible to solve them all but it's important to provide flexibility for enhancement while keeping **ngVue** small and simple. So we introduce a new module **ngVue.plugins**.
+There are more complicated problems when we try to integrate Angular 1.x with Vue.js. It is impossible to solve them all 
+but it's important to provide flexibility for enhancement while keeping `ngVue` small and simple. So we introduce a 
+new module `ngVue.plugins`.
 
 ## Table of Contents
 
 - [the $ngVue factory](#the-ngvue-factory)
 - [Plugins](#plugins)
-	- [available plugins](#available-plugins)
+	- [Available plugins](#available-plugins)
 	- [API: install(callback)](#api-install-callback)
 	- [How to install a plugin](#how-to-install-a-plugin)
 	- [How to set up a plugin](#how-to-set-up-a-plugin)
 	- [How to write a plugin](#how-to-write-a-plugin)
 - [Quirk Mode](#quirk-mode)
+- [Root Vue instance props](#Root-Vue-instance-props)
+  - [Example: Vuex](#Example-Vuex)
 
 ## Usage
 
-**ngVue.plugins** is a UMD module and you can use it in AMD, CommonJS and browser globals.
+`ngVue.plugins` is a UMD module and you can use it in AMD, CommonJS and browser globals.
 
-Make sure that AngularJS 1.x, VueJS and ngVue are loaded and then the plugins module. Register thees module as dependencies in your app: ngVue and ngVue.plugins:
+Make sure that AngularJS 1.x, Vue.js and ngVue are loaded and then the plugins module. Register thees module as dependencies in your app: ngVue and ngVue.plugins:
 
 ```javascript
 import Angular from 'angular'
@@ -32,26 +37,28 @@ import 'ngVue/build/plugins.js'
 angular.module('yourApp', ['ngVue', 'ngVue.plugins'])
 ```
 
-## the $ngVue factory
+## The `$ngVue` factory
 
-**ngVue.plugins** creates an Angular service `$ngVue`. This service implements a **plugins** system and other functionality. For the **plugins**, they will control the Vue instances with the lifecycle hooks, so you can use VueJS plugins or use Angular factories/services resolved by the inject service to VueJS.
+`ngVue.plugins` creates an Angular service `$ngVue`. This service implements a **plugins** system and other functionality.
+For the **plugins**, they will control the Vue instances with the lifecycle hooks, so you can use Vue.js plugins or use 
+Angular factories/services resolved by the inject service to Vue.js.
 
 ## Plugins
 
-### available plugins
+### Available plugins
 
 | name | description |
 | --- | --- |
-| [filters](./plugins.filters.md) | *(built-in)* register Angular filters to VueJS |
+| [filters](./plugins.filters.md) | *(built-in)* register Angular filters to Vue.js |
 
-### API: install(callback)
+### API: `install(callback)`
 
 The provider `$ngVue` has only one method `install` to use a plugin during the configuration phase of Angular.
 
 **Arguments**
 
-- `callback` (*Function*): the callback function receives the inject service `$injector` and this service injects the provider instances only. The callback should return a plain object `{$name[, $config, $vue, $plugin]}`: 
-
+- `callback` (*`Function`*): the callback function receives the inject service `$injector` and this service injects the 
+  provider instances only. The callback should return a plain object `{$name[, $config, $vue, $plugin]}`: 
 	- `$name` (*String*): required to avoid name collisions in the provider, it is used as the namespace in the `$ngVue` provider
 	- `$config` (*Object*): optional, it contains the methods for users to set up the plugin and those methods will be exposed only to the namespace object created by `$name` in the `$ngVue` provider
 	- `$vue` (*Object*): optional, it contains the lifecycle hooks of the Vue instances
@@ -66,7 +73,7 @@ There are two types of lifecycle hooks:
 | ngVue plugins | init |
 | Vue instances | beforeCreated, created, beforeMount, mounted, beforeUpdate, updated, beforeDestroy, destroyed |
 
-For the ngVue plugin hook `init`, it is invoked when the service `$ngVue` is instantiated by the inject service. It is when you can add global-level functionality to VueJS.
+For the ngVue plugin hook `init`, it is invoked when the service `$ngVue` is instantiated by the inject service. It is when you can add global-level functionality to Vue.js.
 
 The Vue instance hooks will be invoked when any Vue instance in Angular application calls its own lifecycle hooks. You can subscribe those hooks to do anything with Angular services (it is not recommended to use Angular services in Vue components).
 
@@ -116,16 +123,16 @@ angular.module('custom.plugin', ['ngVue.plugins'])
 
 ## Quirk Mode
 
-VueJS cannot detect these changes on the scope objects while AngularJS can -- read about their differences in [Caveats](./caveats.md).
+Vue.js cannot detect these changes on the scope objects while AngularJS can -- read about their differences in [Caveats](./caveats.md).
 
 - dynamically add a new property to the reactive object: `vm.b = 'a'`
 - delete a property from the object: `delete vm.b`
 - set an array element with the index: `array[0] = newElement`
 - modify the length of the array: `array.length = 0`
 
-You have to mutate the scope object in a reactive way to trigger the view updates in VueJS. You are likely to refactor all the controller code. So we introduce the quirk mode.
+You have to mutate the scope object in a reactive way to trigger the view updates in Vue.js. You are likely to refactor all the controller code. So we introduce the quirk mode.
 
-The quirk mode enables AngularJS to propagate all the watched changes to VueJS and so you will not have to refactor any controller code to trigger the reactivity system to re-render the components.
+The quirk mode enables AngularJS to propagate all the watched changes to Vue.js and so you will not have to refactor any controller code to trigger the reactivity system to re-render the components.
 
 You can activate it with `$ngVueProvider` during the config phase:
 
@@ -136,18 +143,42 @@ angular.module('yourApp', ['ngVue', 'ngVue.plugins'])
 	})
 ```
 
-## Vuex
+## Root Vue instance props
+Sometimes a plugin requires you to pass extra properties to the root Vue instance in order to access its features on
+any child component. You can use `$ngVueProvider` at a configuration phase of your Angular.js application to
+pass such extra properties. This way you can inject Vuex's `store`, [Vue i18n](https://github.com/kazupon/vue-i18n)'s `i18n`, or your own [custom Vue.js 
+plugin](https://vuejs.org/v2/guide/plugins.html) object.
 
+```javascript
+// app.js
+import Vue from 'vue'
+import myPlugin from './myPlugin'
+
+Vue.use(myPlugin)
+const myPluginFeature = new myPlugin.Feature()
+
+angular.module('yourApp', ['ngVue', 'ngVue.plugins'])
+  .config(($ngVueProvider) => {
+		$ngVueProvider.setRootVueInstanceProps({
+      myPluginFeature: myPluginFeature
+    })
+	})
+```
+
+> Note: Vue's instance [lifecycle hooks](https://vuejs.org/v2/guide/instance.html#Instance-Lifecycle-Hooks) will be discarded when
+> passed through `$ngVueProvider.setRootVueInstanceProps()` as there is already [a mechanism to handle lifecycle hooks](#Lifecycle-hooks)
+
+### Example: Vuex
 Vuex support is a bit opinionated and its implementation focuses on simplicity. You _must_ use `Vue.use(Vuex)`
 to enable automatic injection of the store into child components.
 Then, import (or define) your `Vuex.Store` instance and tell `ngVue` to use it on all Vue instances created by it.
 
-You can enabled it during the config phase of the Angular.js app:
+You can enabled it during the configuration phase of the Angular.js app, using `$ngVueProvider.setRootVueInstanceProps()`:
 
 ```javascript
 // store.js
-import Vue
-import Vuex
+import Vue from 'vue'
+import Vuex from 'vuex'
 
 Vue.use(Vuex)
 
@@ -164,7 +195,9 @@ import store from './store'
 
 angular.module('yourApp', ['ngVue', 'ngVue.plugins'])
   .config(($ngVueProvider) => {
-		$ngVueProvider.setRootVueInstanceProps({store: store})
+		$ngVueProvider.setRootVueInstanceProps({
+      store: store
+    })
 	})
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngVue",
   "author": "Doray Hong <hongduhui@gmail.com>",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Use Vue Components in Angular 1.x",
   "main": "build/index.js",
   "keywords": [

--- a/src/__tests__/rootInstanceProps.test.js
+++ b/src/__tests__/rootInstanceProps.test.js
@@ -1,0 +1,93 @@
+import angular from 'angular'
+import Vue from 'vue'
+import '../plugins'
+
+import ngHtmlCompiler from "./utils/ngHtmlCompiler"
+import Button from './fixtures/ButtonComponent.js'
+
+describe('root Vue instance props', () => {
+  let $rootScope
+  let $ngVue
+  let compileHTML
+
+  function inject () {
+    angular.mock.inject((_$rootScope_, _$compile_, _$ngVue_) => {
+      $ngVue = _$ngVue_
+      $rootScope = _$rootScope_
+      compileHTML = ngHtmlCompiler(_$rootScope_, _$compile_)
+    })
+  }
+
+  beforeEach(() => {
+    angular.mock.module('ngVue')
+    angular.mock.module('ngVue.plugins')
+  })
+
+  describe('Simple props', () => {
+    beforeEach(() => {
+      angular.mock.module((_$ngVueProvider_) => {
+        _$ngVueProvider_.setRootVueInstanceProps({
+          foo: 1,
+          bar: 2,
+          baz: 3
+        })
+      })
+      inject()
+    })
+
+    it("should contain props as defined by in the provider", () => {
+      expect($ngVue.getRootProps().foo).toEqual(1)
+      expect($ngVue.getRootProps().bar).toEqual(2)
+      expect($ngVue.getRootProps().baz).toEqual(3)
+    })
+  })
+
+  describe('Vue hooks as props', () => {
+    const hookNames = [
+      'beforeCreated',
+      'created',
+      'beforeMount',
+      'mounted',
+      'beforeUpdate',
+      'updated',
+      'beforeDestroy',
+      'destroyed'
+    ]
+
+    let $ngVueProvider
+
+    beforeEach(() => {
+      angular.mock.module((_$ngVueProvider_, _$provide_) => {
+        $ngVueProvider = _$ngVueProvider_
+        _$provide_.value('Button', Button)
+      })
+      inject()
+    })
+
+    hookNames.forEach(hookName => {
+      it(`${hookName} should not be SUPER valid!`, () => {
+        let evilProps = {
+          [hookName]: "Hello! I'm SUPER valid!"
+        }
+        $ngVueProvider.setRootVueInstanceProps(evilProps)
+        const props = $ngVue.getRootProps()
+        expect(props[hookName]).not.toEqual("Hello! I'm SUPER valid!")
+      })
+    })
+
+    it('should keep mounted hook untouched', (done) => {
+      $ngVueProvider.setRootVueInstanceProps({
+        mounted: "Awesome! I'm mounted!"
+      })
+      const scope = $rootScope.$new()
+      compileHTML('<vue-component name="Button" />', scope)
+      scope.$digest()
+      Vue.nextTick(() => {
+        expect($ngVue.getRootProps().mounted).not.toEqual("Awesome! I'm mounted!")
+        expect($ngVue.getRootProps().mounted).not.toBeUndefined()
+        expect($ngVue.getRootProps().mounted).toBeInstanceOf(Function)
+        done()
+      })
+    })
+  })
+})

--- a/src/__tests__/vuex.test.js
+++ b/src/__tests__/vuex.test.js
@@ -34,7 +34,7 @@ describe('vuex', () => {
     beforeEach(inject)
 
     it('should not have any Vuex store by default', () => {
-      expect($ngVue.getVuexStore()).toBeUndefined()
+      expect($ngVue.getRootProps().store).toBeUndefined()
     })
   })
 
@@ -47,7 +47,7 @@ describe('vuex', () => {
     })
 
     it('should have a Vuex store', () => {
-      expect($ngVue.getVuexStore()).toEqual(store)
+      expect($ngVue.getRootProps().store).toEqual(store)
     })
 
     it('should render with store data', (done) => {

--- a/src/angular/ngVueLinker.js
+++ b/src/angular/ngVueLinker.js
@@ -23,10 +23,10 @@ export function ngVueLinker (componentName, jqElement, elAttributes, scope, $inj
   const on = evalPropEvents(dataExprsMap, scope) || {}
 
   const inQuirkMode = $ngVue ? $ngVue.inQuirkMode() : false
-  const vueHooks = $ngVue ? $ngVue.getVueHooks() : {}
+  const rootProps = $ngVue ? $ngVue.getRootProps() : {}
 
-  const mounted = vueHooks.mounted
-  vueHooks.mounted = function () {
+  const mounted = rootProps.mounted
+  rootProps.mounted = function () {
     if (jqElement[0].innerHTML.trim()) {
       const html = $compile(jqElement[0].innerHTML)(scope)
       const slot = this.$refs.__slot__
@@ -36,8 +36,6 @@ export function ngVueLinker (componentName, jqElement, elAttributes, scope, $inj
       mounted.apply(this, arguments)
     }
   }
-
-  const vuexStore = $ngVue ? {store: $ngVue.getVuexStore()} : {}
 
   const watchOptions = {
     depth: elAttributes.watchDepth,
@@ -57,8 +55,7 @@ export function ngVueLinker (componentName, jqElement, elAttributes, scope, $inj
         </Component>
       )
     },
-    ...vueHooks,
-    ...vuexStore
+    ...rootProps
   })
 
   scope.$on('$destroy', () => {

--- a/src/plugins/provider.js
+++ b/src/plugins/provider.js
@@ -113,9 +113,7 @@ function ngVueProvider ($injector) {
     Object.assign(rootProps, createVueHooksMap(cb))
 
     return {
-      getRootProps: () => {
-        return rootProps
-      },
+      getRootProps: () => rootProps,
       inQuirkMode: () => inQuirkMode
     }
   }]

--- a/src/plugins/provider.js
+++ b/src/plugins/provider.js
@@ -3,15 +3,19 @@ import Vue from 'vue'
 
 // init
 const pluginHooks = Object.create(null)
+const _warn = (typeof console !== 'undefined' && typeof console.warn === 'function') ? console.warn : () => {} //  Default to a noop function
 
-// beforeCreated
-// created
-// beforeMount
-// mounted
-// beforeUpdate
-// updated
-// beforeDestroy
-// destroyed
+const defaultHooks = [
+  'beforeCreated',
+  'created',
+  'beforeMount',
+  'mounted',
+  'beforeUpdate',
+  'updated',
+  'beforeDestroy',
+  'destroyed'
+]
+
 const vueHooks = Object.create(null)
 
 function addHooks (map, hooks) {
@@ -42,14 +46,43 @@ function createVueHooksMap (hookCallback) {
 
 function ngVueProvider ($injector) {
   let inQuirkMode = false
-  let vuexStore
+  let rootProps = {}
 
   this.activeQuirkMode = () => {
     inQuirkMode = true
   }
 
   this.enableVuex = (store) => {
-    vuexStore = store
+    _warn(`
+    enableVuex() is deprecated and will be removed in a future release.
+    Consider switching to setRootVueInstanceProps().
+    `)
+    Object.assign(rootProps, {store: store})
+  }
+
+  /**
+   * @param {props} Object with arbitrary properties to be added to the root Vue instance (i.e.,
+   * Vuex's `store`, Vue i18n `i18n`, Vue Router's `router`, and so on)
+   *
+   * Usage:
+   * import store from './store'
+   * import i18n from './i18n'
+   * import customProp './customVuePlugin'
+   *
+   * angular.module('app').config(($ngVueProvider) => {
+   *   $ngVueProvider.setRootVueInstanceProps({
+   *     store,
+   *     i18n,
+   *     customProp
+   *   })
+   * })
+   *
+   */
+  this.setRootVueInstanceProps = (props) => {
+    const hooksFound = Object.keys(props).filter(hookName => defaultHooks.includes(hookName))
+    hooksFound.forEach(hookName => delete props[hookName])
+
+    Object.assign(rootProps, props)
   }
 
   this.install = (plugin) => {
@@ -75,11 +108,14 @@ function ngVueProvider ($injector) {
 
     callHooks(pluginHooks, 'init', cb)
 
-    const vueHooks = createVueHooksMap(cb)
+    // Explicitly overwrite any hook defined with `setRootVueInstanceProps` so that
+    // the current behavior is kept and no breaking changes are introduced.
+    Object.assign(rootProps, createVueHooksMap(cb))
 
     return {
-      getVueHooks: () => vueHooks,
-      getVuexStore: () => vuexStore,
+      getRootProps: () => {
+        return rootProps
+      },
       inQuirkMode: () => inQuirkMode
     }
   }]


### PR DESCRIPTION
Sometimes we need to inject properties in the root Vue instance (i.e., Vuex's `store`,
Vue i18n `i18n`, Vue Router's `router`) and the current structure of `ngVue` doesn't allow
us to do that. This change is a proposal to give the user of the library freedom to pass
any property to the root Vue instance created by `ngVue` so that even custom plugins may
be used with it.

In order to keep away from a breaking change, a warning is issued when `$ngVueProvider.enableVuex()` is called. A
new method `$ngVueProvider.setRootViewInstanceProps()` was added where the Vuex store can be added. It
also explicitly _forbids_ passing Vue hooks as a "root prop" as there is already a mechanism to merge
the components lifecycle hooks with `ngVue` callbacks.