### PR TITLE
Throw error if no parent element exists

### DIFF
--- a/src/__tests__/__snapshots__/vue-component.test.js.snap
+++ b/src/__tests__/__snapshots__/vue-component.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`vue-component creation should throw an error if there is no parent tag 1`] = `"ngVue components must have a parent tag or they will not render"`;
+
 exports[`vue-component remove should remove a vue component when ng-if directive flag toggles from true to false 1`] = `
 <div
   class="ng-scope"

--- a/src/__tests__/vue-component.test.js
+++ b/src/__tests__/vue-component.test.js
@@ -15,7 +15,7 @@ describe('vue-component', () => {
   let $rootScope
   let $compile
   let compileHTML
-  
+
   beforeEach(() => {
     angular.mock.module('ngVue')
 
@@ -94,11 +94,10 @@ describe('vue-component', () => {
     })
 
     it('should throw an error if there is no parent tag', () => {
-      expect(()=>{
-        $compile('<vue-component name="HelloComponent" />')($rootScope.$new());
-      }).toThrowErrorMatchingSnapshot();
+      expect(() => {
+        $compile('<vue-component name="HelloComponent" />')($rootScope.$new())
+      }).toThrowErrorMatchingSnapshot()
     })
-
   })
 
   describe('v-props extraction', () => {

--- a/src/__tests__/vue-component.test.js
+++ b/src/__tests__/vue-component.test.js
@@ -13,8 +13,9 @@ import GreetingsComponent from './fixtures/GreetingsComponent'
 describe('vue-component', () => {
   let $provide
   let $rootScope
+  let $compile
   let compileHTML
-
+  
   beforeEach(() => {
     angular.mock.module('ngVue')
 
@@ -24,6 +25,7 @@ describe('vue-component', () => {
 
     angular.mock.inject((_$rootScope_, _$compile_) => {
       $rootScope = _$rootScope_
+      $compile = _$compile_
       compileHTML = ngHtmlCompiler(_$rootScope_, _$compile_)
     })
   })
@@ -90,6 +92,13 @@ describe('vue-component', () => {
         '<div class="foo" style="font-size: 2em;"><span random="hello" tabindex="1" disabled="disabled" data-qa="John">Hello  </span></div>'
       )
     })
+
+    it('should throw an error if there is no parent tag', () => {
+      expect(()=>{
+        $compile('<vue-component name="HelloComponent" />')($rootScope.$new());
+      }).toThrowErrorMatchingSnapshot();
+    })
+
   })
 
   describe('v-props extraction', () => {

--- a/src/angular/ngVueLinker.js
+++ b/src/angular/ngVueLinker.js
@@ -10,6 +10,8 @@ import extractSpecialAttributes from '../components/props/extractSpecialAttribut
 import watchSpecialAttributes from '../components/props/watchSpecialAttributes'
 
 export function ngVueLinker (componentName, jqElement, elAttributes, scope, $injector) {
+  if (!jqElement.parent().length) throw new Error("ngVue components must have a parent tag or they will not render")
+
   const $ngVue = $injector.has('$ngVue') ? $injector.get('$ngVue') : null
   const $compile = $injector.get('$compile')
 


### PR DESCRIPTION
#84 ngVue cannot render the component if it is the top level on an element. This pull request will throw an error if the user attempt to do `$compile('<my-component></my-component>')(scope)`


