### PR TITLE
Suppress logger when NODE_ENV=development

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,10 +1,10 @@
-const isEnvTestOrNotDevelopment =
+const isEnvTestOrProduction =
   typeof process !== 'undefined' &&
   typeof process.env !== 'undefined' &&
-  (process.env.BABEL_ENV === 'test' || process.env.NODE_ENV !== 'development')
+  (process.env.BABEL_ENV === 'test' || process.env.NODE_ENV === 'production')
 
 const warn =
-  typeof console !== 'undefined' && typeof console.warn === 'function' && !isEnvTestOrNotDevelopment
+  typeof console !== 'undefined' && typeof console.warn === 'function' && !isEnvTestOrProduction
     ? console.warn.bind(console)
     : undefined
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,10 +1,10 @@
-const isEnvTestOrDevelopment =
+const isEnvTestOrNotDevelopment =
   typeof process !== 'undefined' &&
   typeof process.env !== 'undefined' &&
   (process.env.BABEL_ENV === 'test' || process.env.NODE_ENV !== 'development')
 
 const warn =
-  typeof console !== 'undefined' && typeof console.warn === 'function' && !isEnvTestOrDevelopment
+  typeof console !== 'undefined' && typeof console.warn === 'function' && !isEnvTestOrNotDevelopment
     ? console.warn.bind(console)
     : undefined
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,8 +1,10 @@
-const isEnvTest =
-  typeof process !== 'undefined' && typeof process.env !== 'undefined' && process.env.BABEL_ENV === 'test'
+const isEnvTestOrDevelopment =
+  typeof process !== 'undefined' &&
+  typeof process.env !== 'undefined' &&
+  (process.env.BABEL_ENV === 'test' || process.env.NODE_ENV !== 'development')
 
 const warn =
-  typeof console !== 'undefined' && typeof console.warn === 'function' && !isEnvTest
+  typeof console !== 'undefined' && typeof console.warn === 'function' && !isEnvTestOrDevelopment
     ? console.warn.bind(console)
     : undefined
 

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ export const ngVue = angular
   .module('ngVue', [])
   .run(function () {
     logger.warn(
-      'camelCase syntax for events name (in $emit function) will be deprecated in a futur release.\nPlease, make sure to use kebab-case syntax when emitting events from Vue.'
+      'camelCase syntax for events name (in $emit function) will be deprecated in a future release.\nPlease, make sure to use kebab-case syntax when emitting events from Vue.'
     )
   })
   .directive('vueComponent', ['$injector', ngVueComponentDirective])


### PR DESCRIPTION
Fixes #94 

- Suppresses the warning when `NODE_ENV=development`
- Fixes typo in warning.