### PR TITLE
Fix Vue mounted lifecycle hook memory leak

### DIFF
--- a/src/__tests__/rootInstanceProps.test.js
+++ b/src/__tests__/rootInstanceProps.test.js
@@ -55,10 +55,17 @@ describe('root Vue instance props', () => {
     ]
 
     let $ngVueProvider
+    let mountedPluginHook
 
     beforeEach(() => {
       angular.mock.module((_$ngVueProvider_, _$provide_) => {
         $ngVueProvider = _$ngVueProvider_
+        mountedPluginHook = jest.fn()
+        $ngVueProvider.install(() => ({
+          $vue: {
+            mounted: mountedPluginHook
+          }
+        }))
         _$provide_.value('Button', Button)
       })
       inject()
@@ -86,6 +93,7 @@ describe('root Vue instance props', () => {
         expect($ngVue.getRootProps().mounted).not.toEqual("Awesome! I'm mounted!")
         expect($ngVue.getRootProps().mounted).not.toBeUndefined()
         expect($ngVue.getRootProps().mounted).toBeInstanceOf(Function)
+        expect(mountedPluginHook).toHaveBeenCalled()
         done()
       })
     })

--- a/src/angular/ngVueLinker.js
+++ b/src/angular/ngVueLinker.js
@@ -30,7 +30,8 @@ export function ngVueLinker (componentName, jqElement, elAttributes, scope, $inj
   const rootProps = $ngVue ? $ngVue.getRootProps() : {}
 
   const mounted = rootProps.mounted
-  rootProps.mounted = function () {
+  const props = Object.assign({}, rootProps)
+  props.mounted = function () {
     const element = jqElement[0]
     if (element.innerHTML.trim()) {
       let html
@@ -72,7 +73,7 @@ export function ngVueLinker (componentName, jqElement, elAttributes, scope, $inj
         </Component>
       )
     },
-    ...rootProps
+    ...props
   })
 
   scope.$on('$destroy', () => {


### PR DESCRIPTION
Thanks for creating ngVue, it has been a great tool while doing the migration from AngularJS. On a large app with lots of Vue components wrapped in ngVue we were noticing some memory issues.

On every ngVue component created the ngVueLinker would set the rootProps.mounted function to be the current function and calling the previous rootProps.mounted function. If numerous Vue components are created via ngVue then each one will have a mounted function that calls all previous mounted functions.

This changes it so that rootProps.mounted is unchanged regardless of the amount of ngVue components.