### PR TITLE
refactor(bootstrap): remove event naming style deprecation warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,10 +58,5 @@ function ngVueComponentDirective($injector) {
 
 export const ngVue = angular
   .module('ngVue', [])
-  .run(function () {
-    logger.warn(
-      'camelCase syntax for events name (in $emit function) will be deprecated in a future release.\nPlease, make sure to use kebab-case syntax when emitting events from Vue.'
-    )
-  })
   .directive('vueComponent', ['$injector', ngVueComponentDirective])
   .factory('createVueComponent', ['$injector', ngVueComponentFactory])


### PR DESCRIPTION
This depecration warnings appears to be warning users of a Vue library limitation.

I don't believe this is ngVue's responibility to police

Closes #148